### PR TITLE
More stix to aql work

### DIFF
--- a/src/modules/qradar/README.md
+++ b/src/modules/qradar/README.md
@@ -1,0 +1,74 @@
+# QRadar
+
+### Format for calling stix-shifter from the command line
+
+python stix_shifter.py `<translator_module>` `<query or result>` `<data>`
+
+## Converting from STIX patterns to AQL queries
+
+This example input pattern:
+
+`python stix_shifter.py "qradar" "query" "[domain-name:value = 'example.com' and mac-addr:value = '00-00-5E-00-53-00']"`
+
+Returns the following AQL query:
+
+`SELECT <defined QRadar fields> FROM events WHERE (sourcemac='00-00-5E-00-53-00' OR destinationmac='00-00-5E-00-53-00') AND domainname='example.com'`
+
+### AQL query construction: SELECT statement
+
+The QRadar event columns that make up the SELECT portion of the AQL query are defined in `aql_event_fields.json`. A default selection is provided, but custom selections can be added to this file.
+
+### AQL query construction: WHERE clause
+
+STIX to AQL field mapping is defined in `from_stix_map.json` <br/>
+STIX attributes that map to multiple AQL fields will have those fields joined by ORs in the returned query. <br/>
+Translated STIX attributes are inserted into the AQL query in the order they are defined in the mapping file. <br/>
+When translating from STIX patterns to AQL queries, the following objects and attributes can be used:
+
+* ipv4-addr:value
+* ipv6-addr:value
+* url:value
+* mac-addr:value
+* domain-name:value
+* file:name
+* network-traffic:src_port, network=traffic:dst_port
+
+## Converting from QRadar events to STIX
+
+QRadar data to STIX mapping is defined in `to_stix_map.json`
+
+This example QRadar data:
+
+`python stix_shifter.py "qradar" "results" '[{"starttime": 1524227777191, "protocolid": 255, "sourceip": "9.21.123.112", "logsourceid":126, "qid": 55500004, "sourceport": 0, "eventcount": 1, "magnitude": 4, "identityip": "0.0.0.0", "destinationip": "9.21.123.112", "destinationport": 0, "category": 10009, "username": null}]'`
+
+Will return the following STIX observable:
+
+```json
+[
+  {
+    "x_com_ibm_uds_datasource": {
+      "id": "7c0de425-33bf-46be-9e38-e42319e36d95",
+      "name": "events"
+    },
+    "id": "observed-data--62392b84-66a7-4984-a49d-7872986e0c48",
+    "type": "observed-data",
+    "objects": {
+      "0": { "type": "ipv4-addr", "value": "9.21.123.112" },
+      "1": { "type": "ipv4-addr", "value": "9.21.123.112" },
+      "2": { "type": "network-traffic", "src_ref": "1", "dst_ref": "0" }
+    },
+    "x_com_ibm_ariel": {
+      "log_source_id": 126,
+      "identity_ip": "0.0.0.0",
+      "protocol_id": 255,
+      "magnitude": 4,
+      "qid": 55500004
+    },
+    "number_observed": 1,
+    "created": "2018-04-20T12:36:17.191Z",
+    "modified": "2018-04-20T12:36:17.191Z",
+    "first_observed": "2018-04-20T12:36:17.191Z",
+    "last_observed": "2018-04-20T12:36:17.191Z"
+  }
+]
+```

--- a/src/modules/qradar/aql_query_constructor.py
+++ b/src/modules/qradar/aql_query_constructor.py
@@ -99,12 +99,20 @@ class AqlQueryStringPatternTranslator:
             comparison_string = ""
             mapped_fields_count = len(mapped_fields_array)
 
+            group_query = (mapped_fields_count > 1)
+
+            if(group_query):
+                comparison_string += "("
+
             for mapped_field in mapped_fields_array:
                 comparison_string += "{mapped_field}{comparator}{value}".format(
                     mapped_field=mapped_field, comparator=comparator, value=value)
                 if (mapped_fields_count > 1):
                     comparison_string += " OR "
                     mapped_fields_count -= 1
+
+            if(group_query):
+                comparison_string += ")"
 
             if expression.comparator == ComparisonComparators.NotEqual:
                 comparison_string = self._negate_comparison(comparison_string)

--- a/src/modules/qradar/aql_query_constructor.py
+++ b/src/modules/qradar/aql_query_constructor.py
@@ -98,12 +98,6 @@ class AqlQueryStringPatternTranslator:
 
             comparison_string = ""
             mapped_fields_count = len(mapped_fields_array)
-
-            group_query = (mapped_fields_count > 1)
-
-            if(group_query):
-                comparison_string += "("
-
             for mapped_field in mapped_fields_array:
                 comparison_string += "{mapped_field}{comparator}{value}".format(
                     mapped_field=mapped_field, comparator=comparator, value=value)
@@ -111,8 +105,10 @@ class AqlQueryStringPatternTranslator:
                     comparison_string += " OR "
                     mapped_fields_count -= 1
 
-            if(group_query):
-                comparison_string += ")"
+            if(len(mapped_fields_array) > 1):
+                # More than one AQL field maps to the STIX attribute so group the ORs.
+                grouped_comparison_string = "(" + comparison_string + ")"
+                comparison_string = grouped_comparison_string
 
             if expression.comparator == ComparisonComparators.NotEqual:
                 comparison_string = self._negate_comparison(comparison_string)

--- a/src/modules/qradar/json/from_stix_map.json
+++ b/src/modules/qradar/json/from_stix_map.json
@@ -1,12 +1,12 @@
 {
   "ipv4-addr": {
     "fields": {
-      "value": ["sourceip", "destinationip"]
+      "value": ["sourceip", "destinationip", "identityip"]
     }
   },
   "ipv6-addr": {
     "fields": {
-      "value": ["sourceip", "destinationip"]
+      "value": ["sourceip", "destinationip", "identityip"]
     }
   },
   "url": {
@@ -22,6 +22,17 @@
   "domain-name": {
     "fields": {
       "value": ["domainname"]
+    }
+  },
+  "file": {
+    "fields": {
+      "name": ["filename"]
+    }
+  },
+  "network-traffic": {
+    "fields": {
+      "src_port": ["sourceport"],
+      "dst_port": ["destinationport"]
     }
   }
 }

--- a/tests/qradar/test_class.py
+++ b/tests/qradar/test_class.py
@@ -1,4 +1,6 @@
 from src.modules.qradar import qradar_translator
+from src.modules.qradar import qradar_data_mapping
+import unittest
 
 selections = "SELECT QIDNAME(qid) as qidname, qid as qid, CATEGORYNAME(category) as categoryname, \
 category as categoryid, CATEGORYNAME(highlevelcategory) as high_level_category_name, \
@@ -9,7 +11,7 @@ username as username, eventdirection as direction, identityip as identityip, ide
 eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol"
 
 
-class TestStixToAql(object):
+class TestStixToAql(unittest.TestCase, object):
 
     def test_ipv4_query(self):
         interface = qradar_translator.Translator()
@@ -75,3 +77,10 @@ class TestStixToAql(object):
         query = interface.transform_query(input_arguments)
         assert query == selections + \
             " FROM events WHERE destinationport='23456' OR sourceport='12345'"
+
+    def test_unmapped_attribute(self):
+        data_mapping_exception = qradar_data_mapping.DataMappingException
+        interface = qradar_translator.Translator()
+        input_arguments = "[network-traffic:some_invalid_attribute = 'whatever']"
+        self.assertRaises(data_mapping_exception,
+                          lambda: interface.transform_query(input_arguments))

--- a/tests/qradar/test_class.py
+++ b/tests/qradar/test_class.py
@@ -16,14 +16,14 @@ class TestStixToAql(object):
         input_arguments = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
         query = interface.transform_query(input_arguments)
         assert query == selections + \
-            " FROM events WHERE (sourceip='192.168.122.84' OR destinationip='192.168.122.84') OR (sourceip='192.168.122.83' OR destinationip='192.168.122.83')"
+            " FROM events WHERE (sourceip='192.168.122.84' OR destinationip='192.168.122.84' OR identityip='192.168.122.84') OR (sourceip='192.168.122.83' OR destinationip='192.168.122.83' OR identityip='192.168.122.83')"
 
     def test_ipv6_query(self):
         interface = qradar_translator.Translator()
         input_arguments = "[ipv6-addr:value = '192.168.122.83']"
         query = interface.transform_query(input_arguments)
         assert query == selections + \
-            " FROM events WHERE (sourceip='192.168.122.83' OR destinationip='192.168.122.83')"
+            " FROM events WHERE (sourceip='192.168.122.83' OR destinationip='192.168.122.83' OR identityip='192.168.122.83')"
 
     def test_url_query(self):
         interface = qradar_translator.Translator()
@@ -61,3 +61,17 @@ class TestStixToAql(object):
         # Expect the STIX and to convert to an AQL AND.
         assert query == selections + \
             " FROM events WHERE (sourcemac='00-00-5E-00-53-00' OR destinationmac='00-00-5E-00-53-00') AND domainname='example.com'"
+
+    def test_file_query(self):
+        # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
+        interface = qradar_translator.Translator()
+        input_arguments = "[file:name = 'some_file.exe']"
+        query = interface.transform_query(input_arguments)
+        assert query == selections + " FROM events WHERE filename='some_file.exe'"
+
+    def test_port_queries(self):
+        interface = qradar_translator.Translator()
+        input_arguments = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
+        query = interface.transform_query(input_arguments)
+        assert query == selections + \
+            " FROM events WHERE destinationport='23456' OR sourceport='12345'"


### PR DESCRIPTION
- Added mapping for STIX file and network-traffic objects. Still need to figure out how to handle queries for file hashes.
- Added parenthesis to resulting AQL so that multiple QRadar fields that map to a STIX type can be group as OR checks.