### PR TITLE
feat(stix-to-aql): Added support for user-account stix object

### DIFF
--- a/stix_shifter/src/modules/qradar/json/from_stix_map.json
+++ b/stix_shifter/src/modules/qradar/json/from_stix_map.json
@@ -34,5 +34,10 @@
       "src_port": ["sourceport"],
       "dst_port": ["destinationport"]
     }
+  },
+  "user-account": {
+    "fields": {
+      "user_id": ["username"]
+    }
   }
 }

--- a/tests/qradar/test_class.py
+++ b/tests/qradar/test_class.py
@@ -94,3 +94,11 @@ class TestStixToAql(unittest.TestCase, object):
         options = {}
         self.assertRaises(data_mapping_exception,
                           lambda: interface.transform_query(input_arguments, options))
+
+    def test_user_account_query(self):
+        interface = qradar_translator.Translator()
+        input_arguments = "[user-account:user_id = 'root']"
+        options = {}
+        query = interface.transform_query(input_arguments, options)
+        assert query == selections + \
+            " FROM events WHERE username='root'"


### PR DESCRIPTION
basically added just user-id property which matches username in aql