### PR TITLE
import sys in mail.py for lines 34 and 35

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from stix_shifter import stix_shifter
 
 


### PR DESCRIPTION
Discovered via the tests in #23

flake8 testing of https://github.com/IBM/stix-shifter on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./main.py:33:27: F821 undefined name 'sys'
        parser.print_help(sys.stderr)
                          ^
./main.py:34:9: F821 undefined name 'sys'
        sys.exit(1)
        ^
2     F821 undefined name 'sys'
2
```