### PR TITLE
feat: return parsed STIX with AQL query

### DIFF
--- a/stix_shifter/src/modules/qradar/README.md
+++ b/stix_shifter/src/modules/qradar/README.md
@@ -2,11 +2,15 @@
 
 ### Format for calling stix-shifter from the command line
 
-python stix_shifter.py `<translator_module>` `<query or result>` `<stix identity object>` `<data>`
+python stix_shifter.py `<translator_module>` `<query or result>` `<STIX identity object>` `<data>`
 
 (Note the identity object is only used when converting from AQL to STIX, but due to positional arguments, an empty hash will need to be passed in when converting from STIX patterns to AQL. Keyword arguments should be implemented to overcome this).
 
 ## Converting from STIX patterns to AQL queries
+
+Returns an object representing the aql query and a parsing of the input stix pattern:
+
+`{'aql_query:' resulting_aql_query_string, 'stix_parsing': [{'attribute': <STIX attribute>, 'comparison_operator': <comparison operator>, 'value': <STIX value>}]}`
 
 This example input pattern:
 
@@ -16,6 +20,9 @@ Returns the following AQL query:
 
 `SELECT <defined QRadar fields> FROM events WHERE (sourcemac='00-00-5E-00-53-00' OR destinationmac='00-00-5E-00-53-00') AND domainname='example.com'`
 
+and returns the parsed STIX pattern:
+
+`[{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]`
 
 ### AQL query construction: SELECT statement
 

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -45,7 +45,6 @@ class AqlQueryStringPatternTranslator:
     def __init__(self, pattern: Pattern, data_model_mapper):
         self.dmm = data_model_mapper
         self.pattern = pattern
-        self.select_prefix = 'SELECT * FROM events WHERE'
         self.parsed_pattern = []
         self.translated = self.parse_expression(pattern)
 

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -45,6 +45,8 @@ class AqlQueryStringPatternTranslator:
     def __init__(self, pattern: Pattern, data_model_mapper):
         self.dmm = data_model_mapper
         self.pattern = pattern
+        self.select_prefix = 'SELECT * FROM events WHERE'
+        self.parsed_pattern = []
         self.translated = self.parse_expression(pattern)
 
         query_split = self.translated.split("split")
@@ -109,6 +111,7 @@ class AqlQueryStringPatternTranslator:
             mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
             # Resolve the comparison symbol to use in the query string (usually just ':')
             comparator = self.comparator_lookup[expression.comparator]
+            original_stix_value = expression.value
 
             if stix_field == 'protocols[*]':
                 map_data = _fetch_network_protocol_mapping()
@@ -135,6 +138,8 @@ class AqlQueryStringPatternTranslator:
                 value = self._format_like(expression.value)
             else:
                 value = self._escape_value(expression.value)
+
+            self.parsed_pattern.append({'attribute': expression.object_path, 'comparison_operator': comparator, 'value': original_stix_value})
 
             comparison_string = ""
             mapped_fields_count = len(mapped_fields_array)
@@ -200,4 +205,4 @@ def translate_pattern(pattern: Pattern, data_model_mapping):
     queries = []
     for query in x.queries:
         queries.append("SELECT {select_statement} FROM events WHERE {where_clause}".format(select_statement=select_statement, where_clause=query))
-    return queries
+    return {'aql_queries': queries, 'parsed_stix': x.parsed_pattern}

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -12,6 +12,8 @@ destinationip as destinationip, destinationport as destinationport, destinationm
 username as username, eventdirection as direction, identityip as identityip, identityhostname as identity_host_name, \
 eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol, UTF8(payload) as payload, URL as url, magnitude as magnitude"
 
+from_statement = " FROM events "
+
 protocols = {
     "tcp": "6",
     "udp": "17",
@@ -37,40 +39,45 @@ class TestStixToAql(unittest.TestCase, object):
         input_arguments = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"]
+        where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
+        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_ipv6_query(self):
         interface = qradar_translator.Translator()
         input_arguments = "[ipv6-addr:value = '192.168.122.83']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert [query == selections +
-                " FROM events WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"]
+        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
+        parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_url_query(self):
         interface = qradar_translator.Translator()
         input_arguments = "[url:value = 'http://www.testaddress.com']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE url = 'http://www.testaddress.com'"]
+        where_statement = "WHERE url = 'http://www.testaddress.com'"
+        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_mac_address_query(self):
         interface = qradar_translator.Translator()
         input_arguments = "[mac-addr:value = '00-00-5E-00-53-00']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"]
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
+        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_domain_query(self):
         interface = qradar_translator.Translator()
         input_arguments = "[domain-name:value = 'example.com']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE domainname = 'example.com'"]
+        where_statement = "WHERE domainname = 'example.com'"
+        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_query_from_multiple_observation_expressions_joined_by_and(self):
         interface = qradar_translator.Translator()
@@ -78,8 +85,9 @@ class TestStixToAql(unittest.TestCase, object):
         options = {}
         query = interface.transform_query(input_arguments, options)
         # Expect the STIX and to convert to an AQL OR.
-        assert query == [selections +
-                         " FROM events WHERE domainname = 'example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"]
+        where_statement = "WHERE domainname = 'example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
+        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_query_from_multiple_comparison_expressions_joined_by_and(self):
         interface = qradar_translator.Translator()
@@ -87,8 +95,9 @@ class TestStixToAql(unittest.TestCase, object):
         options = {}
         query = interface.transform_query(input_arguments, options)
         # Expect the STIX and to convert to an AQL AND.
-        assert query == [selections +
-                         " FROM events WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND domainname = 'example.com'"]
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND domainname = 'example.com'"
+        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_file_query(self):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
@@ -96,15 +105,18 @@ class TestStixToAql(unittest.TestCase, object):
         input_arguments = "[file:name = 'some_file.exe']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections + " FROM events WHERE filename = 'some_file.exe'"]
+        where_statement = "WHERE filename = 'some_file.exe'"
+        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_port_queries(self):
         interface = qradar_translator.Translator()
         input_arguments = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE destinationport = '23456' OR sourceport = '12345'"]
+        where_statement = "WHERE destinationport = '23456' OR sourceport = '12345'"
+        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_unmapped_attribute(self):
         data_mapping_exception = qradar_data_mapping.DataMappingException
@@ -119,8 +131,9 @@ class TestStixToAql(unittest.TestCase, object):
         input_arguments = "[user-account:user_id = 'root']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE username = 'root'"]
+        where_statement = "WHERE username = 'root'"
+        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_invalid_stix_pattern(self):
         stix_validation_exception = base_translator.StixValidationException
@@ -139,31 +152,37 @@ class TestStixToAql(unittest.TestCase, object):
             input_arguments = "[network-traffic:protocols[*] = '" + key + "']"
             options = {}
             query = interface.transform_query(input_arguments, options)
-            assert query == [selections + " FROM events WHERE protocolid = '" + value + "'"]
+        where_statement = "WHERE protocolid = '" + value + "'"
+        parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_network_traffic_start_stop(self):
         interface = qradar_translator.Translator()
         input_arguments = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' or network-traffic:end = '2018-06-14T08:36:24.000Z']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE endtime = '1528965384' OR starttime = '1528965384'"]
+        where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384'"
+        parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_artifact_queries(self):
         interface = qradar_translator.Translator()
         input_arguments = "[artifact:payload_bin matches 'some text']"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert query == [selections +
-                         " FROM events WHERE payload MATCHES '.*some text.*'"]
+        where_statement = "WHERE payload MATCHES '.*some text.*'"
+        parsed_stix = [{'attribute': 'artifact:payload_bin', 'comparison_operator': 'MATCHES', 'value': 'some text'}]
+        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers(self):
         interface = qradar_translator.Translator()
         input_arguments = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START '2016-06-01T01:30:00Z' STOP '2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START '2016-06-01T03:55:00Z' STOP '2016-06-01T04:30:00Z'"
         options = {}
         query = interface.transform_query(input_arguments, options)
-        assert len(query) == 2
-        assert query == [selections +
-                         " FROM events WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00'STOP'2016-06-01 02:20:00'",
-                         selections +
-                         " FROM events WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00'STOP'2016-06-01 04:30:00'"]
+        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00'STOP'2016-06-01 02:20:00'"
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00'STOP'2016-06-01 04:30:00'"
+        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
+                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
+                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        assert len(query['aql_queries']) == 2
+        assert query == {'aql_queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}


### PR DESCRIPTION
Returns an array of parsed STIX attributes, comparison operators, and values used in the stix pattern argument when constructing an AQL query from a STIX pattern.