### PR TITLE
feat: Return STIX parsing when creating query from a STIX pattern

### DIFF
--- a/stix_shifter/src/modules/base/base_translator.py
+++ b/stix_shifter/src/modules/base/base_translator.py
@@ -1,11 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from .base_result_translator import BaseResultTranslator
 from .base_query_translator import BaseQueryTranslator
-from stix2patterns.validator import run_validator
-
-
-class StixValidationException(Exception):
-    pass
 
 
 class BaseTranslator:
@@ -39,9 +34,4 @@ class BaseTranslator:
         :rtype: str
         """
 
-        errors = run_validator(data)
-        if (errors != []):
-            raise StixValidationException(
-                "The STIX pattern has the following errors: {}".format(errors))
-        else:
-            return self.query_translator.transform_query(data, options, mapping)
+        return self.query_translator.transform_query(data, options, mapping)

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -46,7 +46,6 @@ class AqlQueryStringPatternTranslator:
     def __init__(self, pattern: Pattern, data_model_mapper):
         self.dmm = data_model_mapper
         self.pattern = pattern
-        self.parsed_pattern = []
         self.translated = self.parse_expression(pattern)
 
         query_split = self.translated.split("split")
@@ -139,8 +138,6 @@ class AqlQueryStringPatternTranslator:
             else:
                 value = self._escape_value(expression.value)
 
-            self.parsed_pattern.append({'attribute': expression.object_path, 'comparison_operator': comparator, 'value': original_stix_value})
-
             comparison_string = ""
             mapped_fields_count = len(mapped_fields_array)
             for mapped_field in mapped_fields_array:
@@ -209,4 +206,4 @@ def translate_pattern(pattern: Pattern, data_model_mapping):
     queries = []
     for query in x.queries:
         queries.append("SELECT {select_statement} FROM events WHERE {where_clause}".format(select_statement=select_statement, where_clause=query))
-    return {'aql_queries': queries, 'parsed_stix': x.parsed_pattern}
+    return queries

--- a/stix_shifter/src/stix_pattern_parser/stix_pattern_parser.py
+++ b/stix_shifter/src/stix_pattern_parser/stix_pattern_parser.py
@@ -4,7 +4,6 @@ from stix_shifter.src.patterns.pattern_objects import ObservationExpression, Com
 
 
 class PatternTranslator:
-    # Based on AQL comparison operators
     comparator_lookup = {
         ComparisonExpressionOperators.And: "AND",
         ComparisonExpressionOperators.Or: "OR",
@@ -21,7 +20,8 @@ class PatternTranslator:
         # Treat AND's as OR's -- Unsure how two ObsExps wouldn't cancel each other out.
         ObservationOperators.And: 'OR',
         ObservationOperators.FollowedBy: 'FOLLOWEDBY',
-        ComparisonComparators.IsSubSet: 'INCIDR',
+        ComparisonComparators.IsSubSet: 'ISSUBSET',
+        ComparisonComparators.IsSuperSet: 'ISSUPERSET',
     }
 
     def __init__(self, pattern: Pattern):

--- a/stix_shifter/src/stix_pattern_parser/stix_pattern_parser.py
+++ b/stix_shifter/src/stix_pattern_parser/stix_pattern_parser.py
@@ -1,0 +1,74 @@
+from stix_shifter.src.patterns.pattern_objects import ObservationExpression, ComparisonExpression, \
+    ComparisonExpressionOperators, ComparisonComparators, Pattern, \
+    CombinedComparisonExpression, CombinedObservationExpression, ObservationOperators
+
+
+class PatternTranslator:
+    # Based on AQL comparison operators
+    comparator_lookup = {
+        ComparisonExpressionOperators.And: "AND",
+        ComparisonExpressionOperators.Or: "OR",
+        ComparisonComparators.GreaterThan: ">",
+        ComparisonComparators.GreaterThanOrEqual: ">=",
+        ComparisonComparators.LessThan: "<",
+        ComparisonComparators.LessThanOrEqual: "<=",
+        ComparisonComparators.Equal: "=",
+        ComparisonComparators.NotEqual: "!=",
+        ComparisonComparators.Like: "LIKE",
+        ComparisonComparators.In: "IN",
+        ComparisonComparators.Matches: 'MATCHES',
+        ObservationOperators.Or: 'OR',
+        # Treat AND's as OR's -- Unsure how two ObsExps wouldn't cancel each other out.
+        ObservationOperators.And: 'OR',
+        ObservationOperators.FollowedBy: 'FOLLOWEDBY',
+        ComparisonComparators.IsSubSet: 'INCIDR',
+    }
+
+    def __init__(self, pattern: Pattern):
+        self.pattern = pattern
+        self.parsed_pattern = []
+        self.translated = self.parse_expression(pattern)
+        self.queries = [self.translated]
+
+    def _parse_expression(self, expression) -> str:
+        if isinstance(expression, ComparisonExpression):  # Base Case
+            # Resolve STIX Object Path to a field in the target Data Model
+            stix_object, stix_field = expression.object_path.split(':')
+            comparator = self.comparator_lookup[expression.comparator]
+            self.parsed_pattern.append({'attribute': expression.object_path, 'comparison_operator': comparator, 'value': expression.value})
+            return ""
+
+        elif isinstance(expression, CombinedComparisonExpression):
+            query_string = "{} {} {}".format(self._parse_expression(expression.expr1),
+                                             self.comparator_lookup[expression.operator],
+                                             self._parse_expression(expression.expr2))
+
+            return "{query_string}".format(query_string=query_string)
+        elif isinstance(expression, ObservationExpression):
+            return self._parse_expression(expression.comparison_expression)
+        elif hasattr(expression, 'observation_expression'):
+            if isinstance(expression.observation_expression, CombinedObservationExpression):
+                operator = self.comparator_lookup[expression.observation_expression.operator]
+                return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.observation_expression.expr1),
+                                                           operator=operator,
+                                                           expr2=self._parse_expression(expression.observation_expression.expr2))
+            else:
+                return self._parse_expression(expression.observation_expression.comparison_expression)
+        elif isinstance(expression, CombinedObservationExpression):
+            operator = self.comparator_lookup[expression.operator]
+            return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.expr1),
+                                                       operator=operator,
+                                                       expr2=self._parse_expression(expression.expr2))
+        elif isinstance(expression, Pattern):
+            return "{expr}".format(expr=self._parse_expression(expression.expression))
+        else:
+            raise RuntimeError("Unknown Recursion Case for expression={}, type(expression)={}".format(
+                expression, type(expression)))
+
+    def parse_expression(self, pattern: Pattern):
+        return self._parse_expression(pattern)
+
+
+def parse_stix(pattern: Pattern):
+    x = PatternTranslator(pattern)
+    return x.parsed_pattern

--- a/stix_shifter/stix_shifter.py
+++ b/stix_shifter/stix_shifter.py
@@ -1,10 +1,17 @@
 import sys
 import importlib
+from stix_shifter.src.patterns.parser import generate_query
+from stix2patterns.validator import run_validator
+from stix_shifter.src.stix_pattern_parser import stix_pattern_parser
 
 
 MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic']
 RESULTS = 'results'
 QUERY = 'query'
+
+
+class StixValidationException(Exception):
+    pass
 
 
 class StixShifter:
@@ -39,8 +46,21 @@ class StixShifter:
         interface = translator_module.Translator()
 
         if translate_type == QUERY:
-            # Converting STIX pattern to datasource query
-            return interface.transform_query(data, options)
+            # return interface.transform_query(data, options)
+
+            errors = run_validator(data)
+            if (errors != []):
+                raise StixValidationException(
+                    "The STIX pattern has the following errors: {}".format(errors))
+            else:
+                # Translating STIX pattern to antlr query object
+                query_object = generate_query(data)
+                # Converting query object to datasource query
+                parsed_stix = stix_pattern_parser.parse_stix(query_object)
+                # Todo: pass in the query_object instead of the data so we can remove multiple generate_query calls.
+                # Converting STIX pattern to datasource query
+                queries = interface.transform_query(data, options)
+                return {'queries': queries, 'parsed_stix': parsed_stix}
         elif translate_type == RESULTS:
             # Converting data from the datasource to STIX objects
             return interface.translate_results(data_source, data, options)

--- a/stix_shifter/stix_shifter.py
+++ b/stix_shifter/stix_shifter.py
@@ -46,8 +46,6 @@ class StixShifter:
         interface = translator_module.Translator()
 
         if translate_type == QUERY:
-            # return interface.transform_query(data, options)
-
             errors = run_validator(data)
             if (errors != []):
                 raise StixValidationException(

--- a/tests/patterns/test_analytic_translator.py
+++ b/tests/patterns/test_analytic_translator.py
@@ -6,6 +6,7 @@ from os import listdir, path
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 class TestAnalyticTranslator(unittest.TestCase):
     """ Integration tests for the full pattern conversion process"""
     longMessage = True
@@ -14,14 +15,16 @@ class TestAnalyticTranslator(unittest.TestCase):
     @staticmethod
     def success_test_generator(pattern, search_platform, data_model, expected_result):
         """ Generates a successful test """
+
         def test(self):
             res = translate(pattern, search_platform, data_model)
-            self.assertEqual(normalize_spacing(res), normalize_spacing(expected_result))
+            self.assertEqual(normalize_spacing(res['queries']), normalize_spacing(expected_result))
         return test
 
     @staticmethod
     def failure_test_generator(pattern, search_platform, data_model):
         """ Generates a test for an error """
+
         def test(self):
             with self.assertRaises(Exception):
                 res = translate(pattern, search_platform, data_model)
@@ -40,7 +43,7 @@ class TestAnalyticTranslator(unittest.TestCase):
 
             # Generate a test for each remaining key in the dictionary
             for platform, expected_result in v.items():
-                if '-' in platform and platform != "stix-input": # Filter out keys that aren't actually platforms
+                if '-' in platform and platform != "stix-input":  # Filter out keys that aren't actually platforms
                     dm, sp = platform.split('-')
 
                     # each test has name in the format: test_md5_hash_car-splunk
@@ -56,5 +59,6 @@ class TestAnalyticTranslator(unittest.TestCase):
                         new_test = TestAnalyticTranslator.failure_test_generator(test_pattern, search_platform,
                                                                                  data_model)
                         setattr(TestAnalyticTranslator, test_name, new_test)
+
 
 TestAnalyticTranslator.generate_tests()

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -1,7 +1,5 @@
-from stix_shifter.src.modules.qradar import qradar_translator
+from stix_shifter import stix_shifter
 from stix_shifter.src.modules.qradar import qradar_data_mapping
-from stix_shifter.src.modules.base import base_translator
-from stix_shifter.src.exceptions import DataMappingException
 import unittest
 import random
 
@@ -32,168 +30,136 @@ protocols = {
     "sctp": "132"
 }
 
+shifter = stix_shifter.StixShifter()
+
 
 class TestStixToAql(unittest.TestCase, object):
 
     def test_ipv4_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
+
         where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_ipv6_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[ipv6-addr:value = '192.168.122.83']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[ipv6-addr:value = '192.168.122.83']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
         parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_url_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[url:value = 'http://www.testaddress.com']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[url:value = 'http://www.testaddress.com']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE url = 'http://www.testaddress.com'"
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_mac_address_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[mac-addr:value = '00-00-5E-00-53-00']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_domain_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[domain-name:value = 'example.com']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[domain-name:value = 'example.com']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE domainname = 'example.com'"
         parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_query_from_multiple_observation_expressions_joined_by_and(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[domain-name:value = 'example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[domain-name:value = 'example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
         where_statement = "WHERE domainname = 'example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
         parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_query_from_multiple_comparison_expressions_joined_by_and(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[domain-name:value = 'example.com' and mac-addr:value = '00-00-5E-00-53-00']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[domain-name:value = 'example.com' and mac-addr:value = '00-00-5E-00-53-00']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND domainname = 'example.com'"
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_file_query(self):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
-        interface = qradar_translator.Translator()
-        input_arguments = "[file:name = 'some_file.exe']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[file:name = 'some_file.exe']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE filename = 'some_file.exe'"
         parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_port_queries(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE destinationport = '23456' OR sourceport = '12345'"
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_unmapped_attribute(self):
-        data_mapping_exception = DataMappingException
-        interface = qradar_translator.Translator()
-        input_arguments = "[network-traffic:some_invalid_attribute = 'whatever']"
-        options = {}
+        data_mapping_exception = qradar_data_mapping.DataMappingException
+        stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
         self.assertRaises(data_mapping_exception,
-                          lambda: interface.transform_query(input_arguments, options))
+                          lambda: shifter.translate('qradar', 'query', '{}', stix_pattern))
 
     def test_user_account_query(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[user-account:user_id = 'root']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[user-account:user_id = 'root']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE username = 'root'"
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_invalid_stix_pattern(self):
-        stix_validation_exception = base_translator.StixValidationException
-        interface = qradar_translator.Translator()
-        input_arguments = "[not_a_valid_pattern]"
-        options = {}
+        stix_validation_exception = stix_shifter.StixValidationException
+        stix_pattern = "[not_a_valid_pattern]"
         self.assertRaises(stix_validation_exception,
-                          lambda: interface.transform_query(input_arguments, options))
+                          lambda: shifter.translate('qradar', 'query', '{}', stix_pattern))
 
     def test_network_traffic_protocols(self):
-        interface = qradar_translator.Translator()
         for key, value in protocols.items():
             # Test for both upper and lower case protocols in the STIX pattern
             if random.randint(0, 1) == 0:
                 key = key.upper()
-            input_arguments = "[network-traffic:protocols[*] = '" + key + "']"
-            options = {}
-            query = interface.transform_query(input_arguments, options)
+            stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
+            query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE protocolid = '" + value + "'"
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_network_traffic_start_stop(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' or network-traffic:end = '2018-06-14T08:36:24.000Z']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' or network-traffic:end = '2018-06-14T08:36:24.000Z']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384'"
         parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_artifact_queries(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[artifact:payload_bin matches 'some text']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[artifact:payload_bin matches 'some text']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE payload MATCHES '.*some text.*'"
         parsed_stix = [{'attribute': 'artifact:payload_bin', 'comparison_operator': 'MATCHES', 'value': 'some text'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START '2016-06-01T01:30:00Z' STOP '2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START '2016-06-01T03:55:00Z' STOP '2016-06-01T04:30:00Z'"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START '2016-06-01T01:30:00Z' STOP '2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START '2016-06-01T03:55:00Z' STOP '2016-06-01T04:30:00Z'"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00'STOP'2016-06-01 02:20:00'"
         where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00'STOP'2016-06-01 04:30:00'"
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert len(query['aql_queries']) == 2
-        assert query == {'aql_queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
+        assert len(query['queries']) == 2
+        assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
 
     def test_set_operators(self):
-        interface = qradar_translator.Translator()
-        input_arguments = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
-        options = {}
-        query = interface.transform_query(input_arguments, options)
+        stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip))"
         parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'INCIDR', 'attribute': 'ipv4-addr:value'}]
-        assert query == {'aql_queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
-
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -161,5 +161,5 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip))"
-        parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'INCIDR', 'attribute': 'ipv4-addr:value'}]
+        parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'ISSUBSET', 'attribute': 'ipv4-addr:value'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}

--- a/web_api.py
+++ b/web_api.py
@@ -12,7 +12,8 @@ from stix_shifter.src.patterns.translator import translate, SearchPlatforms, Dat
 
 app = Flask(__name__.split('.')[0])
 
-def run_server(): # used only by test module to start dev server
+
+def run_server():  # used only by test module to start dev server
     app.run(debug=True, port=5000, host='127.0.0.1')
 
 
@@ -24,7 +25,7 @@ def car_elastic():
         pattern = request.data.decode("utf-8")  # decode the input string
         output = translate(
             pattern, outputLanguage, outputDataModel)
-        return output
+        return output['queries']
     else:
         print("No Request Data")  # when issues with input data
         return "No Request Data"
@@ -38,28 +39,31 @@ def car_splunk():
         pattern = request.data.decode("utf-8")  # decode the input string
         output = translate(
             pattern, outputLanguage, outputDataModel)
-        return output
+        return output['queries']
     else:
         print("No Request Data")  # when issues with input data
         return "No Request Data"
+
 
 @app.route('/cim-splunk', methods=['POST'])
 def cim_splunk():
     outputLanguage = SearchPlatforms.SPLUNK
     outputDataModel = DataModels.CIM
     if request.data:
-        pattern = request.data.decode("utf-8") # decode the input string
+        pattern = request.data.decode("utf-8")  # decode the input string
         output = translate(
             pattern, outputLanguage, outputDataModel
         )
-        return output
+        return output['queries']
     else:
-        print("No Request Data") # when issues with input data
+        print("No Request Data")  # when issues with input data
         return "No Request Data"
+
 
 def main():
     app.run(debug=True, port=5000, host='127.0.0.1')
 
+
 if __name__ == '__main__':
-    #### DEVELOPMENT Settings, change for production!!!
+    # DEVELOPMENT Settings, change for production!!!
     main()


### PR DESCRIPTION
 Return an array of objects representing a parsing of the stix pattern along with the translated datasource query. An example of a returned stix parsing is:

`[{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]`

