### PR TITLE
Timestamp fix

### DIFF
--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -57,11 +57,13 @@ class AqlQueryStringPatternTranslator:
             query_array = list(map(lambda x: re.sub("\s?(OR|AND)\s?$", "", x), query_array))
             # remove empty strings in the array
             query_array = list(map(lambda x: x.strip(), list(filter(None, query_array))))
-            # transform time format from '2014-04-25T15:51:20Z' into '2014-04-25 15:51:20'
-            t_pattern = "((?<=START'\d{4}-\d{2}-\d{2})(T))|((?<=STOP'\d{4}-\d{2}-\d{2})(T))"
-            query_array = list(map(lambda x: re.sub(t_pattern, " ", x), query_array))
-            r_pattern = "((?<=\d{2}:\d{2}:\d{2})(Z))"
-            query_array = list(map(lambda x: re.sub(r_pattern, "", x), query_array))
+            # transform time format from t'2014-04-25T15:51:20Z' into '2014-04-25 15:51:20'
+            big_t_pattern = "((?<=STARTt'\d{4}-\d{2}-\d{2})(T))|((?<=STOPt'\d{4}-\d{2}-\d{2})(T))"
+            query_array = list(map(lambda x: re.sub(big_t_pattern, " ", x), query_array))
+            big_z_pattern = "(?<=\d{2}:\d{2}:\d{2})Z"
+            query_array = list(map(lambda x: re.sub(big_z_pattern, "", x), query_array))
+            little_t_pattern = "(?<=START)t|(?<=STOP)t"
+            query_array = list(map(lambda x: re.sub(little_t_pattern, "", x), query_array))
             self.queries = query_array
         else:
             self.queries = query_split
@@ -144,9 +146,9 @@ class AqlQueryStringPatternTranslator:
             comparison_string = ""
             mapped_fields_count = len(mapped_fields_array)
             for mapped_field in mapped_fields_array:
-                # if its a set operator() query construction will be different. 
+                # if its a set operator() query construction will be different.
                 if expression.comparator == ComparisonComparators.IsSubSet:
-                    comparison_string +=  comparator + "(" + "'" + value + "'," + mapped_field +")"
+                    comparison_string += comparator + "(" + "'" + value + "'," + mapped_field + ")"
                 else:
                     comparison_string += "{mapped_field} {comparator} {value}".format(
                         mapped_field=mapped_field, comparator=comparator, value=value)

--- a/stix_shifter/src/patterns/grammar/STIXPattern.g4
+++ b/stix_shifter/src/patterns/grammar/STIXPattern.g4
@@ -61,7 +61,7 @@ stringLiteral  // Add parse rule to make getting string literals easier
   ;
 
 startStopQualifier
-  : START StringLiteral STOP StringLiteral
+  : START TimestampLiteral STOP TimestampLiteral
   ;
 
 withinQualifier

--- a/stix_shifter/stix_shifter.py
+++ b/stix_shifter/stix_shifter.py
@@ -3,6 +3,7 @@ import importlib
 from stix_shifter.src.patterns.parser import generate_query
 from stix2patterns.validator import run_validator
 from stix_shifter.src.stix_pattern_parser import stix_pattern_parser
+import re
 
 
 MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic']
@@ -46,7 +47,13 @@ class StixShifter:
         interface = translator_module.Translator()
 
         if translate_type == QUERY:
+            errors = []
             errors = run_validator(data)
+            # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
+            start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(:\d+)?Z'\sSTOP"
+            pattern_match = bool(re.search(start_stop_pattern, data))
+            if (not pattern_match):
+                errors = run_validator(data)
             if (errors != []):
                 raise StixValidationException(
                     "The STIX pattern has the following errors: {}".format(errors))

--- a/stix_shifter/stix_shifter.py
+++ b/stix_shifter/stix_shifter.py
@@ -48,7 +48,6 @@ class StixShifter:
 
         if translate_type == QUERY:
             errors = []
-            errors = run_validator(data)
             # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
             start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(:\d+)?Z'\sSTOP"
             pattern_match = bool(re.search(start_stop_pattern, data))

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -147,7 +147,7 @@ class TestStixToAql(unittest.TestCase, object):
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_two_observations(self):
-        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START '2016-06-01T01:30:00Z' STOP '2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START '2016-06-01T03:55:00Z' STOP '2016-06-01T04:30:00Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START t'2016-06-01T01:30:00Z' STOP t'2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00Z' STOP t'2016-06-01T04:30:00Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00'STOP'2016-06-01 02:20:00'"
         where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00'STOP'2016-06-01 04:30:00'"
@@ -158,7 +158,7 @@ class TestStixToAql(unittest.TestCase, object):
         assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_three_observations(self):
-        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START '2016-06-01T00:00:00Z' STOP '2016-06-01T01:11:11Z' OR [domain-name:value = 'example.com'] OR [ipv4-addr:value = '333.333.333.0'] START '2016-06-07T02:22:22Z' STOP '2016-06-07T03:33:33Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00Z' STOP t'2016-06-01T01:11:11Z' OR [domain-name:value = 'example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22Z' STOP t'2016-06-07T03:33:33Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' START'2016-06-01 00:00:00'STOP'2016-06-01 01:11:11'"
         where_statement_02 = "WHERE domainname = 'example.com'"


### PR DESCRIPTION
- Handle leading 't' in START STOP timestamps

- Temporarily turning off pattern validation if the pattern contains START STOP qualifier as this isn't yet supported in the validator.