### PR TITLE
Millisecond timestamp support

### DIFF
--- a/stix_shifter/src/modules/qradar/json/aql_event_fields.json
+++ b/stix_shifter/src/modules/qradar/json/aql_event_fields.json
@@ -25,7 +25,8 @@
     "PROTOCOLNAME(protocolid) as protocol",
     "payload as payload",
     "URL as url",
-    "magnitude as magnitude"
+    "magnitude as magnitude",
+    "Filename as filename"
   ],
   "domain-name": [
     "QIDNAME(qid) as qidname",

--- a/stix_shifter/src/modules/qradar/json/from_stix_map.json
+++ b/stix_shifter/src/modules/qradar/json/from_stix_map.json
@@ -19,11 +19,6 @@
       "value": ["sourcemac", "destinationmac"]
     }
   },
-  "domain-name": {
-    "fields": {
-      "value": ["domainname"]
-    }
-  },
   "file": {
     "fields": {
       "name": ["filename"]

--- a/stix_shifter/src/modules/qradar/json/to_stix_map.json
+++ b/stix_shifter/src/modules/qradar/json/to_stix_map.json
@@ -94,8 +94,8 @@
   "url": {
     "key": "url.value"
   },
-  "domain": {
-    "key": "domain-name.value"
+  "filename": {
+    "key": "file.name"
   },
   "payload": {
     "key": "artifact.payload_bin"

--- a/stix_shifter/stix_shifter.py
+++ b/stix_shifter/stix_shifter.py
@@ -49,7 +49,7 @@ class StixShifter:
         if translate_type == QUERY:
             errors = []
             # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
-            start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(:\d+)?Z'\sSTOP"
+            start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'\sSTOP"
             pattern_match = bool(re.search(start_stop_pattern, data))
             if (not pattern_match):
                 errors = run_validator(data)

--- a/tests/qradar_json_to_stix/test_class.py
+++ b/tests/qradar_json_to_stix/test_class.py
@@ -59,11 +59,9 @@ class TestTransform(object):
         payload = "SomeBase64Payload"
         user_id = "someuserid2018"
         url = "https://example.com"
-        domain = "example.com"
         source_ip = "127.0.0.1"
         destination_ip = "255.255.255.1"
-        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url,
-                "domain": domain, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000}
+        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000}
 
         result_bundle = json_to_stix_translator.convert_to_stix(
             data_source, map_data, [data], transformers.get_all_transformers(), options)
@@ -79,7 +77,7 @@ class TestTransform(object):
         nt_object = TestTransform.get_first_of_type(objects.values(), 'network-traffic')
         assert(nt_object is not None), 'network-traffic object type not found'
         assert(nt_object.keys() ==
-            {'type', 'src_port', 'dst_port', 'src_ref', 'dst_ref', 'protocols'})
+               {'type', 'src_port', 'dst_port', 'src_ref', 'dst_ref', 'protocols'})
         assert(nt_object['src_port'] == 3000)
         assert(nt_object['dst_port'] == 2000)
         assert(nt_object['protocols'] == ['tcp'])
@@ -103,11 +101,6 @@ class TestTransform(object):
         assert(curr_obj.keys() == {'type', 'value'})
         assert(curr_obj['value'] == url)
 
-        curr_obj = TestTransform.get_first_of_type(objects.values(), 'domain-name')
-        assert(curr_obj is not None), 'domain-name object type not found'
-        assert(curr_obj.keys() == {'type', 'value'})
-        assert(curr_obj['value'] == domain)
-
         curr_obj = TestTransform.get_first_of_type(objects.values(), 'artifact')
         assert(curr_obj is not None), 'artifact object type not found'
         assert(curr_obj.keys() == {'type', 'payload_bin'})
@@ -118,7 +111,7 @@ class TestTransform(object):
         assert(curr_obj.keys() == {'type', 'user_id'})
         assert(curr_obj['user_id'] == user_id)
 
-        assert(objects.keys() == set(map(str, range(0, 7))))
+        assert(objects.keys() == set(map(str, range(0, 6))))
 
     def test_custom_props(self):
         data = {"logsourceid": 126, "qid": 55500004,

--- a/tests/qradar_json_to_stix/test_class.py
+++ b/tests/qradar_json_to_stix/test_class.py
@@ -61,7 +61,8 @@ class TestTransform(object):
         url = "https://example.com"
         source_ip = "127.0.0.1"
         destination_ip = "255.255.255.1"
-        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000}
+        file_name = "somefile.exe"
+        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000, "filename": file_name}
 
         result_bundle = json_to_stix_translator.convert_to_stix(
             data_source, map_data, [data], transformers.get_all_transformers(), options)
@@ -111,7 +112,12 @@ class TestTransform(object):
         assert(curr_obj.keys() == {'type', 'user_id'})
         assert(curr_obj['user_id'] == user_id)
 
-        assert(objects.keys() == set(map(str, range(0, 6))))
+        curr_obj = TestTransform.get_first_of_type(objects.values(), 'file')
+        assert(curr_obj is not None), 'file object type not found'
+        assert(curr_obj.keys() == {'type', 'name'})
+        assert(curr_obj['name'] == file_name)
+
+        assert(objects.keys() == set(map(str, range(0, 7))))
 
     def test_custom_props(self):
         data = {"logsourceid": 126, "qid": 55500004,

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -147,10 +147,10 @@ class TestStixToAql(unittest.TestCase, object):
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_two_observations(self):
-        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START t'2016-06-01T01:30:00Z' STOP t'2016-06-01T02:20:00Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00Z' STOP t'2016-06-01T04:30:00Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00.123Z' STOP t'2016-06-01T04:30:00.123Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00'STOP'2016-06-01 02:20:00'"
-        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00'STOP'2016-06-01 04:30:00'"
+        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00.123Z'STOP'2016-06-01 02:20:00.123Z'"
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00.123Z'STOP'2016-06-01 04:30:00.123Z'"
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
@@ -158,11 +158,11 @@ class TestStixToAql(unittest.TestCase, object):
         assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_three_observations(self):
-        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00Z' STOP t'2016-06-01T01:11:11Z' OR [domain-name:value = 'example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22Z' STOP t'2016-06-07T03:33:33Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00.123Z' STOP t'2016-06-01T01:11:11.456Z' OR [domain-name:value = 'example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22.789Z' STOP t'2016-06-07T03:33:33.012Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' START'2016-06-01 00:00:00'STOP'2016-06-01 01:11:11'"
+        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' START'2016-06-01 00:00:00.123Z'STOP'2016-06-01 01:11:11.456Z'"
         where_statement_02 = "WHERE domainname = 'example.com'"
-        where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') START'2016-06-07 02:22:22'STOP'2016-06-07 03:33:33'"
+        where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') START'2016-06-07 02:22:22.789Z'STOP'2016-06-07 03:33:33.012Z'"
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'},

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -9,7 +9,7 @@ highlevelcategory as high_level_category_id, logsourceid as logsourceid, LOGSOUR
 endtime as endtime, devicetime as devicetime, sourceip as sourceip, sourceport as sourceport, sourcemac as sourcemac, \
 destinationip as destinationip, destinationport as destinationport, destinationmac as destinationmac, \
 username as username, eventdirection as direction, identityip as identityip, identityhostname as identity_host_name, \
-eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol, payload as payload, URL as url, magnitude as magnitude"
+eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol, payload as payload, URL as url, magnitude as magnitude, Filename as filename"
 
 from_statement = " FROM events "
 
@@ -64,27 +64,20 @@ class TestStixToAql(unittest.TestCase, object):
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
-    def test_domain_query(self):
-        stix_pattern = "[domain-name:value = 'example.com']"
-        query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE domainname = 'example.com'"
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
-
     def test_query_from_multiple_observation_expressions_joined_by_and(self):
-        stix_pattern = "[domain-name:value = 'example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
+        stix_pattern = "[url:value = 'www.example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
-        where_statement = "WHERE domainname = 'example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
+        where_statement = "WHERE url = 'www.example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
+        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_query_from_multiple_comparison_expressions_joined_by_and(self):
-        stix_pattern = "[domain-name:value = 'example.com' and mac-addr:value = '00-00-5E-00-53-00']"
+        stix_pattern = "[url:value = 'www.example.com' and mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
-        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND domainname = 'example.com'"
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND url = 'www.example.com'"
+        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_file_query(self):
@@ -158,14 +151,14 @@ class TestStixToAql(unittest.TestCase, object):
         assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_three_observations(self):
-        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00.123Z' STOP t'2016-06-01T01:11:11.456Z' OR [domain-name:value = 'example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22.789Z' STOP t'2016-06-07T03:33:33.012Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00.123Z' STOP t'2016-06-01T01:11:11.456Z' OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22.789Z' STOP t'2016-06-07T03:33:33.012Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' START'2016-06-01 00:00:00.123Z'STOP'2016-06-01 01:11:11.456Z'"
-        where_statement_02 = "WHERE domainname = 'example.com'"
+        where_statement_02 = "WHERE url = 'www.example.com'"
         where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') START'2016-06-07 02:22:22.789Z'STOP'2016-06-07 03:33:33.012Z'"
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'},
+                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'}]
         assert len(query['queries']) == 3
         assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02, selections + from_statement + where_statement_03], 'parsed_stix': parsed_stix}


### PR DESCRIPTION
- Fix for milliseconds in START STOP timestamps
- Removed domain name from Qradar mappings since it's not a supported AQL field
- Added aql-to-stix mapping for filename. We had this mapped from six-to-aql, but was never handling it coming back from the datasource.

Note that like URL, Filename is a custom AQL attribute so we may want think about removing these from the default mapping files.