### PR TITLE
Custom mappings

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,15 @@ import json
 def __main__():
     """
     In the case of converting a stix pattern to datasource query, arguments will take the form of...
-    <module> <translate_type> <data>
+    <module> <translate_type> <data> <options>
     The module and translate_type will determine what module and method gets called
+    Options argument comes in as:
+      "{
+          "select_fields": <string array of fields in the datasource select statement>},
+          "mapping": <mapping hash for either stix pattern to datasource or data results to stix observation objects>,
+          "result_limit": <integer to limit number or results in the data source query>,
+          "time_range": <time window (ie. last 5 minutes) used in the data source query when START STOP qualifiers are absent>
+       }"
     """
 
     # process arguments
@@ -33,7 +40,6 @@ def __main__():
                                   help='run stix2 validator against the converted results')
     translate_parser.add_argument('-m', '--data-mapper',
                                   help='module to use for the data mapper')
-    # translate_parser.add_argument('-options', help='options that can be passed in')
 
     args = parser.parse_args()
 
@@ -41,7 +47,6 @@ def __main__():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    # args.options = "{\"select_fields\": [\"<FIELDS YOU WANT TO BRING BACK>\"}, \"from_stix_map\": {<HASH OF MAPPING>}}"
     options = json.loads(args.options) if bool(args.options) else {}
     if args.stix_validator:
         options['stix_validator'] = args.stix_validator

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from stix_shifter import stix_shifter
+import json
 
 
 def __main__():
@@ -26,6 +27,7 @@ def __main__():
         'data_source', help='STIX identity object representing a datasource')
     translate_parser.add_argument(
         'data', type=str, help='the data to be translated')
+    translate_parser.add_argument('options', help='options that can be passed in')
     # optional arguments
     translate_parser.add_argument('-x', '--stix-validator', action='store_true',
                                   help='run stix2 validator against the converted results')
@@ -38,7 +40,8 @@ def __main__():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    options = {}
+    # args.options = "{\"select_fields\": [\"<FIELDS YOU WANT TO BRING BACK>\"}, \"from_stix_map\": {<HASH OF MAPPING>}}"
+    options = json.loads(args.options) or {}
     if args.stix_validator:
         options['stix_validator'] = args.stix_validator
     if args.data_mapper:

--- a/main.py
+++ b/main.py
@@ -27,12 +27,13 @@ def __main__():
         'data_source', help='STIX identity object representing a datasource')
     translate_parser.add_argument(
         'data', type=str, help='the data to be translated')
-    translate_parser.add_argument('options', help='options that can be passed in')
+    translate_parser.add_argument('options', nargs='?', help='options that can be passed in')
     # optional arguments
     translate_parser.add_argument('-x', '--stix-validator', action='store_true',
                                   help='run stix2 validator against the converted results')
     translate_parser.add_argument('-m', '--data-mapper',
                                   help='module to use for the data mapper')
+    # translate_parser.add_argument('-options', help='options that can be passed in')
 
     args = parser.parse_args()
 
@@ -41,7 +42,7 @@ def __main__():
         sys.exit(1)
 
     # args.options = "{\"select_fields\": [\"<FIELDS YOU WANT TO BRING BACK>\"}, \"from_stix_map\": {<HASH OF MAPPING>}}"
-    options = json.loads(args.options) or {}
+    options = json.loads(args.options) if bool(args.options) else {}
     if args.stix_validator:
         options['stix_validator'] = args.stix_validator
     if args.data_mapper:

--- a/stix_shifter/src/json_to_stix/json_to_stix.py
+++ b/stix_shifter/src/json_to_stix/json_to_stix.py
@@ -19,15 +19,17 @@ class JSONToStix(BaseResultTranslator):
         :return: STIX formatted results
         :rtype: str
         """
+
+        self.mapping_json = options['mapping'] if 'mapping' in options else {}
         json_data = json.loads(data)
         data_source = json.loads(data_source)
 
-        if(mapping is None):
+        if(not bool(self.mapping_json)):
             # If no mapping is passed in then we will use the default to_stix_map in the qradar module
             map_file = open(self.default_mapping_file_path).read()
             map_data = json.loads(map_file)
         else:
-            map_data = json.loads(mapping)
+            map_data = self.mapping_json
 
         results = json_to_stix_translator.convert_to_stix(data_source, map_data,
                                                           json_data, transformers.get_all_transformers(), options)

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -43,9 +43,10 @@ class AqlQueryStringPatternTranslator:
         ObservationOperators.And: 'OR'
     }
 
-    def __init__(self, pattern: Pattern, data_model_mapper):
+    def __init__(self, pattern: Pattern, data_model_mapper, map_json):
         self.dmm = data_model_mapper
         self.pattern = pattern
+        self.map_json = map_json
         self.translated = self.parse_expression(pattern)
 
         query_split = self.translated.split("SPLIT")
@@ -112,7 +113,7 @@ class AqlQueryStringPatternTranslator:
             # Resolve STIX Object Path to a field in the target Data Model
             stix_object, stix_field = expression.object_path.split(':')
             # Multiple QRadar fields may map to the same STIX Object
-            mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
+            mapped_fields_array = self.dmm.map_field(stix_object, stix_field, self.map_json)
             # Resolve the comparison symbol to use in the query string (usually just ':')
             comparator = self.comparator_lookup[expression.comparator]
             original_stix_value = expression.value
@@ -205,8 +206,8 @@ class AqlQueryStringPatternTranslator:
         return self._parse_expression(pattern)
 
 
-def translate_pattern(pattern: Pattern, data_model_mapping):
-    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping)
+def translate_pattern(pattern: Pattern, data_model_mapping, map_json=None):
+    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping, map_json)
     select_statement = x.dmm.map_selections()
     queries = []
     for query in x.queries:

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -43,10 +43,9 @@ class AqlQueryStringPatternTranslator:
         ObservationOperators.And: 'OR'
     }
 
-    def __init__(self, pattern: Pattern, data_model_mapper, map_json):
+    def __init__(self, pattern: Pattern, data_model_mapper):
         self.dmm = data_model_mapper
         self.pattern = pattern
-        self.map_json = map_json
         self.translated = self.parse_expression(pattern)
 
         query_split = self.translated.split("SPLIT")
@@ -113,7 +112,7 @@ class AqlQueryStringPatternTranslator:
             # Resolve STIX Object Path to a field in the target Data Model
             stix_object, stix_field = expression.object_path.split(':')
             # Multiple QRadar fields may map to the same STIX Object
-            mapped_fields_array = self.dmm.map_field(stix_object, stix_field, self.map_json)
+            mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
             # Resolve the comparison symbol to use in the query string (usually just ':')
             comparator = self.comparator_lookup[expression.comparator]
             original_stix_value = expression.value
@@ -206,8 +205,8 @@ class AqlQueryStringPatternTranslator:
         return self._parse_expression(pattern)
 
 
-def translate_pattern(pattern: Pattern, data_model_mapping, map_json=None):
-    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping, map_json)
+def translate_pattern(pattern: Pattern, data_model_mapping):
+    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping)
     select_statement = x.dmm.map_selections()
     queries = []
     for query in x.queries:

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -43,9 +43,10 @@ class AqlQueryStringPatternTranslator:
         ObservationOperators.And: 'OR'
     }
 
-    def __init__(self, pattern: Pattern, data_model_mapper):
+    def __init__(self, pattern: Pattern, data_model_mapper, result_limit):
         self.dmm = data_model_mapper
         self.pattern = pattern
+        self.result_limit = result_limit
         self.translated = self.parse_expression(pattern)
 
         query_split = self.translated.split("SPLIT")
@@ -167,18 +168,18 @@ class AqlQueryStringPatternTranslator:
             if expression.negated:
                 comparison_string = self._negate_comparison(comparison_string)
             if qualifier is not None:
-                return "SPLIT{comparison} {qualifier}SPLIT".format(comparison=comparison_string, qualifier=qualifier)
+                return "SPLIT{} {} {}SPLIT".format(comparison_string, self.result_limit, qualifier)
             else:
-                return "{comparison}".format(comparison=comparison_string)
+                return "{}".format(comparison_string)
 
         elif isinstance(expression, CombinedComparisonExpression):
             query_string = "{} {} {}".format(self._parse_expression(expression.expr1),
                                              self.comparator_lookup[expression.operator],
                                              self._parse_expression(expression.expr2))
             if qualifier is not None:
-                return "SPLIT{query_string} {qualifier}SPLIT".format(query_string=query_string, qualifier=qualifier)
+                return "SPLIT{} {} {}SPLIT".format(query_string, self.result_limit, qualifier)
             else:
-                return "{query_string}".format(query_string=query_string)
+                return "{}".format(query_string)
         elif isinstance(expression, ObservationExpression):
             return self._parse_expression(expression.comparison_expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
@@ -205,10 +206,19 @@ class AqlQueryStringPatternTranslator:
         return self._parse_expression(pattern)
 
 
-def translate_pattern(pattern: Pattern, data_model_mapping):
-    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping)
+def _test_for_start_stop(query_string) -> bool:
+    pattern = "START'\d{4}(-\d{2}){2}\s\d{2}(:\d{2}){2}(\.\d+)?Z?'\s?STOP"
+    match = re.search(pattern, query_string)
+    return bool(match)
+
+
+def translate_pattern(pattern: Pattern, data_model_mapping, result_limit, timerange=None):
+    x = AqlQueryStringPatternTranslator(pattern, data_model_mapping, result_limit)
     select_statement = x.dmm.map_selections()
     queries = []
     for query in x.queries:
-        queries.append("SELECT {select_statement} FROM events WHERE {where_clause}".format(select_statement=select_statement, where_clause=query))
+        if(_test_for_start_stop(query)):
+            queries.append("SELECT {} FROM events WHERE {}".format(select_statement, query))
+        else:
+            queries.append("SELECT {} FROM events WHERE {} {}".format(select_statement, query, result_limit))
     return queries

--- a/stix_shifter/src/modules/qradar/qradar_data_mapping.py
+++ b/stix_shifter/src/modules/qradar/qradar_data_mapping.py
@@ -23,14 +23,6 @@ class QRadarDataMapper:
         self.mapping_json = options['mapping'] if 'mapping' in options else {}
         self.select_fields_json = options['select_fields'] if 'select_fields' in options else {}
 
-    def map_object(self, stix_object_name):
-        self.map_data = _fetch_mapping()
-        if stix_object_name in self.map_data and self.map_data[stix_object_name] != None:
-            return self.map_data[stix_object_name]
-        else:
-            raise DataMappingException(
-                "Unable to map object `{}` into AQL".format(stix_object_name))
-
     def map_field(self, stix_object_name, stix_property_name):
         self.map_data = self.mapping_json or _fetch_mapping()
         if stix_object_name in self.map_data and stix_property_name in self.map_data[stix_object_name]["fields"]:

--- a/stix_shifter/src/modules/qradar/qradar_data_mapping.py
+++ b/stix_shifter/src/modules/qradar/qradar_data_mapping.py
@@ -2,6 +2,7 @@ from os import path
 import json
 from stix_shifter.src.exceptions import DataMappingException
 
+
 def _fetch_mapping():
     try:
         basepath = path.dirname(__file__)
@@ -26,8 +27,8 @@ class QRadarDataMapper:
             raise DataMappingException(
                 "Unable to map object `{}` into AQL".format(stix_object_name))
 
-    def map_field(self, stix_object_name, stix_property_name):
-        self.map_data = _fetch_mapping()
+    def map_field(self, stix_object_name, stix_property_name, map_json=None):
+        self.map_data = map_json or _fetch_mapping()
         if stix_object_name in self.map_data and stix_property_name in self.map_data[stix_object_name]["fields"]:
             return self.map_data[stix_object_name]["fields"][stix_property_name]
         else:

--- a/stix_shifter/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/src/modules/qradar/stix_to_aql.py
@@ -25,6 +25,8 @@ class StixToAQL(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = qradar_data_mapping.QRadarDataMapper(options)
+        result_limit = options['result_limit'] if 'result_limit' in options else 'limit 10000'
+        timerange = options['timerange'] if 'timerange' in options else None
         query_string = aql_query_constructor.translate_pattern(
-            query_object, data_model_mapper)
+            query_object, data_model_mapper, result_limit, timerange)
         return query_string

--- a/stix_shifter/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/src/modules/qradar/stix_to_aql.py
@@ -24,7 +24,11 @@ class StixToAQL(BaseQueryTranslator):
         logger.info("Converting STIX2 Pattern to ariel")
 
         query_object = generate_query(data)
+        if 'from_stix_map' in options:
+            mapping_json = options['from_stix_map']
+        else:
+            mapping_json = None
         data_model_mapper = qradar_data_mapping.QRadarDataMapper()
         query_string = aql_query_constructor.translate_pattern(
-            query_object, data_model_mapper)
+            query_object, data_model_mapper, mapping_json)
         return query_string

--- a/stix_shifter/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/src/modules/qradar/stix_to_aql.py
@@ -24,11 +24,7 @@ class StixToAQL(BaseQueryTranslator):
         logger.info("Converting STIX2 Pattern to ariel")
 
         query_object = generate_query(data)
-        if 'from_stix_map' in options:
-            mapping_json = options['from_stix_map']
-        else:
-            mapping_json = None
-        data_model_mapper = qradar_data_mapping.QRadarDataMapper()
+        data_model_mapper = qradar_data_mapping.QRadarDataMapper(options)
         query_string = aql_query_constructor.translate_pattern(
-            query_object, data_model_mapper, mapping_json)
+            query_object, data_model_mapper)
         return query_string

--- a/tests/qradar_json_to_stix/test_class.py
+++ b/tests/qradar_json_to_stix/test_class.py
@@ -59,7 +59,7 @@ class TestTransform(object):
         payload = "SomeBase64Payload"
         user_id = "someuserid2018"
         url = "https://example.com"
-        source_ip = "127.0.0.1"
+        source_ip = "fd80:655e:171d:30d4:fd80:655e:171d:30d4"
         destination_ip = "255.255.255.1"
         file_name = "somefile.exe"
         data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000, "filename": file_name}
@@ -94,7 +94,7 @@ class TestTransform(object):
         assert(ip_ref in objects), f"src_ref with key {nt_object['src_ref']} not found"
         ip_obj = objects[ip_ref]
         assert(ip_obj.keys() == {'type', 'value'})
-        assert(ip_obj['type'] == 'ipv4-addr')
+        assert(ip_obj['type'] == 'ipv6-addr')
         assert(ip_obj['value'] == source_ip)
 
         curr_obj = TestTransform.get_first_of_type(objects.values(), 'url')

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -30,6 +30,8 @@ protocols = {
     "sctp": "132"
 }
 
+default_limit = "limit 10000"
+
 shifter = stix_shifter.StixShifter()
 
 
@@ -39,28 +41,28 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
 
-        where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
+        where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {}".format(default_limit)
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = '192.168.122.83']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83')"
+        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {}".format(default_limit)
         parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE url = 'http://www.testaddress.com'"
+        where_statement = "WHERE url = 'http://www.testaddress.com' {}".format(default_limit)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {}".format(default_limit)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -68,7 +70,7 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[url:value = 'www.example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
-        where_statement = "WHERE url = 'www.example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')"
+        where_statement = "WHERE url = 'www.example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {}".format(default_limit)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -76,7 +78,7 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[url:value = 'www.example.com' and mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
-        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND url = 'www.example.com'"
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND url = 'www.example.com' {}".format(default_limit)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -84,14 +86,14 @@ class TestStixToAql(unittest.TestCase, object):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
         stix_pattern = "[file:name = 'some_file.exe']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE filename = 'some_file.exe'"
+        where_statement = "WHERE filename = 'some_file.exe' {}".format(default_limit)
         parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE destinationport = '23456' OR sourceport = '12345'"
+        where_statement = "WHERE destinationport = '23456' OR sourceport = '12345' {}".format(default_limit)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -104,7 +106,7 @@ class TestStixToAql(unittest.TestCase, object):
     def test_user_account_query(self):
         stix_pattern = "[user-account:user_id = 'root']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE username = 'root'"
+        where_statement = "WHERE username = 'root' {}".format(default_limit)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -121,29 +123,29 @@ class TestStixToAql(unittest.TestCase, object):
                 key = key.upper()
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
             query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE protocolid = '" + value + "'"
+        where_statement = "WHERE protocolid = '{}' {}".format(value, default_limit)
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' or network-traffic:end = '2018-06-14T08:36:24.000Z']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384'"
+        where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384' {}".format(default_limit)
         parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_artifact_queries(self):
         stix_pattern = "[artifact:payload_bin matches 'some text']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE payload MATCHES '.*some text.*'"
+        where_statement = "WHERE payload MATCHES '.*some text.*' {}".format(default_limit)
         parsed_stix = [{'attribute': 'artifact:payload_bin', 'comparison_operator': 'MATCHES', 'value': 'some text'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_start_stop_qualifiers_with_two_observations(self):
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00.123Z' STOP t'2016-06-01T04:30:00.123Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' START'2016-06-01 01:30:00.123Z'STOP'2016-06-01 02:20:00.123Z'"
-        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') START'2016-06-01 03:55:00.123Z'STOP'2016-06-01 04:30:00.123Z'"
+        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START'2016-06-01 01:30:00.123Z'STOP'2016-06-01 02:20:00.123Z'".format(default_limit)
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START'2016-06-01 03:55:00.123Z'STOP'2016-06-01 04:30:00.123Z'".format(default_limit)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
@@ -153,9 +155,9 @@ class TestStixToAql(unittest.TestCase, object):
     def test_start_stop_qualifiers_with_three_observations(self):
         stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00.123Z' STOP t'2016-06-01T01:11:11.456Z' OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22.789Z' STOP t'2016-06-07T03:33:33.012Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' START'2016-06-01 00:00:00.123Z'STOP'2016-06-01 01:11:11.456Z'"
-        where_statement_02 = "WHERE url = 'www.example.com'"
-        where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') START'2016-06-07 02:22:22.789Z'STOP'2016-06-07 03:33:33.012Z'"
+        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START'2016-06-01 00:00:00.123Z'STOP'2016-06-01 01:11:11.456Z'".format(default_limit)
+        where_statement_02 = "WHERE url = 'www.example.com' {}".format(default_limit)
+        where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') {} START'2016-06-07 02:22:22.789Z'STOP'2016-06-07 03:33:33.012Z'".format(default_limit)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
@@ -166,7 +168,7 @@ class TestStixToAql(unittest.TestCase, object):
     def test_set_operators(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip))"
+        where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip)) {}".format(default_limit)
         parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'ISSUBSET', 'attribute': 'ipv4-addr:value'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -191,7 +193,7 @@ class TestStixToAql(unittest.TestCase, object):
         }
 
         query = shifter.translate('qradar', 'query', '{}', stix_pattern, options)
-        where_statement = "WHERE sourceip = '192.168.122.83'"
+        where_statement = "WHERE sourceip = '192.168.122.83' {}".format(default_limit)
         parsed_stix = [{'value': '192.168.122.83', 'comparison_operator': '=', 'attribute': 'ipv4-addr:value'}]
         custom_selections = "SELECT sourceip as sourceip, sourceport as sourceport, destinationip as destinationip, destinationport as destinationport, username as username, eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol"
         assert query == {'queries': [custom_selections + from_statement + where_statement], 'parsed_stix': parsed_stix}


### PR DESCRIPTION
Six-shifter now takes in an options hash that allows for custom translation mappings for STIX patterns to AQL query, custom AQL field select, custom JSON to STIX mapping (for data sources that return JSON), custom query limit, and custom time window (when START STOP aren't used). 