### PR TITLE
fix: add optional timerange to AQL query

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ def __main__():
       "{
           "select_fields": <string array of fields in the datasource select statement>},
           "mapping": <mapping hash for either stix pattern to datasource or data results to stix observation objects>,
-          "result_limit": <integer to limit number or results in the data source query>,
-          "timerange": <time window (ie. last 5 minutes) used in the data source query when START STOP qualifiers are absent>
+          "result_limit": <integer limit number for max results in the data source query>,
+          "timerange": <integer time window in minutes used in the data source query when START STOP qualifiers are absent>
        }"
     """
 

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -168,7 +168,7 @@ class AqlQueryStringPatternTranslator:
             if expression.negated:
                 comparison_string = self._negate_comparison(comparison_string)
             if qualifier is not None:
-                return "SPLIT{} {} {}SPLIT".format(comparison_string, self.result_limit, qualifier)
+                return "SPLIT{} limit {} {}SPLIT".format(comparison_string, self.result_limit, qualifier)
             else:
                 return "{}".format(comparison_string)
 
@@ -177,7 +177,7 @@ class AqlQueryStringPatternTranslator:
                                              self.comparator_lookup[expression.operator],
                                              self._parse_expression(expression.expr2))
             if qualifier is not None:
-                return "SPLIT{} {} {}SPLIT".format(query_string, self.result_limit, qualifier)
+                return "SPLIT{} limit {} {}SPLIT".format(query_string, self.result_limit, qualifier)
             else:
                 return "{}".format(query_string)
         elif isinstance(expression, ObservationExpression):
@@ -217,8 +217,13 @@ def translate_pattern(pattern: Pattern, data_model_mapping, result_limit, timera
     select_statement = translated_where_statements.dmm.map_selections()
     queries = []
     for where_statement in translated_where_statements.queries:
-        if(_test_for_start_stop(where_statement)):
-            queries.append("SELECT {} FROM events WHERE {}".format(select_statement, where_statement))
+        has_start_stop = _test_for_start_stop(where_statement)
+        if(has_start_stop):
+            query = "SELECT {} FROM events WHERE {}".format(select_statement, where_statement)
         else:
-            queries.append("SELECT {} FROM events WHERE {} {}".format(select_statement, where_statement, result_limit))
+            query = "SELECT {} FROM events WHERE {} limit {}".format(select_statement, where_statement, result_limit)
+        if(not has_start_stop):
+            query += " last {} minutes".format(timerange)
+        queries.append(query)
+
     return queries

--- a/stix_shifter/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/src/modules/qradar/aql_query_constructor.py
@@ -219,11 +219,8 @@ def translate_pattern(pattern: Pattern, data_model_mapping, result_limit, timera
     for where_statement in translated_where_statements.queries:
         has_start_stop = _test_for_start_stop(where_statement)
         if(has_start_stop):
-            query = "SELECT {} FROM events WHERE {}".format(select_statement, where_statement)
+            queries.append("SELECT {} FROM events WHERE {}".format(select_statement, where_statement))
         else:
-            query = "SELECT {} FROM events WHERE {} limit {}".format(select_statement, where_statement, result_limit)
-        if(not has_start_stop):
-            query += " last {} minutes".format(timerange)
-        queries.append(query)
+            queries.append("SELECT {} FROM events WHERE {} limit {} last {} minutes".format(select_statement, where_statement, result_limit, timerange))
 
     return queries

--- a/stix_shifter/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/src/modules/qradar/stix_to_aql.py
@@ -25,8 +25,8 @@ class StixToAQL(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = qradar_data_mapping.QRadarDataMapper(options)
-        result_limit = options['result_limit'] if 'result_limit' in options else 'limit 10000'
-        timerange = options['timerange'] if 'timerange' in options else None
+        result_limit = options['result_limit'] if 'result_limit' in options else 10000
+        timerange = options['timerange'] if 'timerange' in options else 5
         query_string = aql_query_constructor.translate_pattern(
             query_object, data_model_mapper, result_limit, timerange)
         return query_string

--- a/tests/qradar_stix_to_aql/test_class.py
+++ b/tests/qradar_stix_to_aql/test_class.py
@@ -31,6 +31,7 @@ protocols = {
 }
 
 default_limit = "limit 10000"
+default_time = "last 5 minutes"
 
 shifter = stix_shifter.StixShifter()
 
@@ -41,28 +42,28 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' or ipv4-addr:value = '192.168.122.84']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
 
-        where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {}".format(default_limit)
+        where_statement = "WHERE (sourceip = '192.168.122.84' OR destinationip = '192.168.122.84' OR identityip = '192.168.122.84') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = '192.168.122.83']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {}".format(default_limit)
+        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE url = 'http://www.testaddress.com' {}".format(default_limit)
+        where_statement = "WHERE url = 'http://www.testaddress.com' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {}".format(default_limit)
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -70,7 +71,7 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[url:value = 'www.example.com'] and [mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
-        where_statement = "WHERE url = 'www.example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {}".format(default_limit)
+        where_statement = "WHERE url = 'www.example.com' OR (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -78,7 +79,7 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[url:value = 'www.example.com' and mac-addr:value = '00-00-5E-00-53-00']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
-        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND url = 'www.example.com' {}".format(default_limit)
+        where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND url = 'www.example.com' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -86,14 +87,14 @@ class TestStixToAql(unittest.TestCase, object):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
         stix_pattern = "[file:name = 'some_file.exe']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE filename = 'some_file.exe' {}".format(default_limit)
+        where_statement = "WHERE filename = 'some_file.exe' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 or network-traffic:dst_port = 23456]"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE destinationport = '23456' OR sourceport = '12345' {}".format(default_limit)
+        where_statement = "WHERE destinationport = '23456' OR sourceport = '12345' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -106,7 +107,7 @@ class TestStixToAql(unittest.TestCase, object):
     def test_user_account_query(self):
         stix_pattern = "[user-account:user_id = 'root']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE username = 'root' {}".format(default_limit)
+        where_statement = "WHERE username = 'root' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -123,21 +124,21 @@ class TestStixToAql(unittest.TestCase, object):
                 key = key.upper()
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
             query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE protocolid = '{}' {}".format(value, default_limit)
+        where_statement = "WHERE protocolid = '{}' {} {}".format(value, default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' or network-traffic:end = '2018-06-14T08:36:24.000Z']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384' {}".format(default_limit)
+        where_statement = "WHERE endtime = '1528965384' OR starttime = '1528965384' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
     def test_artifact_queries(self):
         stix_pattern = "[artifact:payload_bin matches 'some text']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE payload MATCHES '.*some text.*' {}".format(default_limit)
+        where_statement = "WHERE payload MATCHES '.*some text.*' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'artifact:payload_bin', 'comparison_operator': 'MATCHES', 'value': 'some text'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -156,7 +157,7 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START t'2016-06-01T00:00:00.123Z' STOP t'2016-06-01T01:11:11.456Z' OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0'] START t'2016-06-07T02:22:22.789Z' STOP t'2016-06-07T03:33:33.012Z'"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
         where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START'2016-06-01 00:00:00.123Z'STOP'2016-06-01 01:11:11.456Z'".format(default_limit)
-        where_statement_02 = "WHERE url = 'www.example.com' {}".format(default_limit)
+        where_statement_02 = "WHERE url = 'www.example.com' {} {}".format(default_limit, default_time)
         where_statement_03 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') {} START'2016-06-07 02:22:22.789Z'STOP'2016-06-07 03:33:33.012Z'".format(default_limit)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
@@ -168,7 +169,7 @@ class TestStixToAql(unittest.TestCase, object):
     def test_set_operators(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = shifter.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip)) {}".format(default_limit)
+        where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip)) {} {}".format(default_limit, default_time)
         parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'ISSUBSET', 'attribute': 'ipv4-addr:value'}]
         assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
 
@@ -193,7 +194,17 @@ class TestStixToAql(unittest.TestCase, object):
         }
 
         query = shifter.translate('qradar', 'query', '{}', stix_pattern, options)
-        where_statement = "WHERE sourceip = '192.168.122.83' {}".format(default_limit)
+        where_statement = "WHERE sourceip = '192.168.122.83' {} {}".format(default_limit, default_time)
         parsed_stix = [{'value': '192.168.122.83', 'comparison_operator': '=', 'attribute': 'ipv4-addr:value'}]
         custom_selections = "SELECT sourceip as sourceip, sourceport as sourceport, destinationip as destinationip, destinationport as destinationport, username as username, eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol"
         assert query == {'queries': [custom_selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+
+    def test_custom_time_limit_and_result_count(self):
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
+        timerange = 25
+        result_limit = 5000
+        options = {"timerange": timerange, "result_limit": result_limit}
+        query = shifter.translate('qradar', 'query', '{}', stix_pattern, options)
+        where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') limit {} last {} minutes".format(result_limit, timerange)
+        parsed_stix = [{'value': '192.168.122.83', 'comparison_operator': '=', 'attribute': 'ipv4-addr:value'}]
+        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}


### PR DESCRIPTION
`result_limit` and `timerange` are passed in as integer options. Result limit defaults to 10000 and time range defaults to 5 (minutes)