### PR TITLE
fix: update requests package to latest version (2.20.1) 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,5 +17,5 @@ pytest==3.5.0
 pytest-cov==2.5.1
 six==1.11.0
 wrapt==1.10.11
-requests==2.18.4
+requests==2.20.1
 flask==1.0.2


### PR DESCRIPTION
Anything below 2.20.0 had a security vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2018-18074