### PR TITLE
fix: check for UNKNOWN hash type

### DIFF
--- a/stix_shifter/stix_translation/src/json_to_stix/json_to_stix_translator.py
+++ b/stix_shifter/stix_translation/src/json_to_stix/json_to_stix_translator.py
@@ -146,16 +146,19 @@ class DataSourceObjToStixObj:
                 continue
 
             generic_hash_key = ''
-            # Use callback function to run logic specific to the data source
-            if self.callback:
-                try:
-                    generic_hash_key = self.callback(obj, ds_key, self.options)
-                except(Exception):
-                    continue
-
             # get the stix keys that are mapped
             ds_key_def_obj = self.ds_to_stix_map[ds_key]
-            ds_key_def_list = ds_key_def_obj if isinstance(ds_key_def_obj, list) else [ds_key_def_obj]
+            if isinstance(ds_key_def_obj, list):
+                ds_key_def_list = ds_key_def_obj
+            else:
+                # Use callback function to run module-specific logic to handle unknown filehash types
+                if self.callback:
+                    try:
+                        generic_hash_key = self.callback(obj, ds_key, ds_key_def_obj['key'], self.options)
+                    except(Exception):
+                        continue
+                ds_key_def_list = [ds_key_def_obj]
+
             for ds_key_def in ds_key_def_list:
                 if ds_key_def is None or 'key' not in ds_key_def:
                     print('{} is not valid (None, or missing key)'.format(ds_key_def))

--- a/stix_shifter/stix_translation/src/modules/qradar/qradar_utils.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/qradar_utils.py
@@ -2,16 +2,20 @@ class FileHashLookupException(Exception):
     pass
 
 
-def hash_type_lookup(obj, ds_key, options):
+def hash_type_lookup(obj, ds_key, mapped_stix_attribute, options):
+    UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE = 'file.hashes.UNKNOWN'
     hash_options = options.get('hash_options', {})
     log_source_id_map = hash_options.get('log_source_id_map', {})
     generic_hash_name = hash_options.get('generic_name', '')
     if not generic_hash_name or ds_key != generic_hash_name:
-        # Current key is not generic hash, so return and let regular mapping resume
-        return ''
+        if mapped_stix_attribute == UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE:
+            raise FileHashLookupException("Generic hash type found that doesn't match generic name")
+        else:
+            # Current key is not generic hash, so return and let regular mapping resume
+            return ''
     else:
         generic_hash_value = obj[generic_hash_name]
-        # These values must match with the aliases set in aql_event_fields.json
+        # These values must match with the aliases set in the select fields
         for type in ["sha256hash", "md5hash", "sha1hash"]:
             if type in obj and obj[type] == generic_hash_value:
                 raise FileHashLookupException("Generic hash value already exists in specific hash-type result")
@@ -22,8 +26,4 @@ def hash_type_lookup(obj, ds_key, options):
         else:
             hash_type = log_source_id_map.get(logsourceid)
             hash_type = hash_type.upper()
-            # Raise and skip if type is still set to the unknown flag
-            if hash_type == 'UNKNOWN':
-                raise FileHashLookupException("Invalid {} hash type".format(hash_type))
-            else:
-                return "file.hashes.{}".format(hash_type)
+            return "file.hashes.{}".format(hash_type.upper())

--- a/tests/stix_translation/test_qradar_json_to_stix.py
+++ b/tests/stix_translation/test_qradar_json_to_stix.py
@@ -6,6 +6,7 @@ from stix_shifter.stix_translation import stix_translation
 
 interface = qradar_translator.Translator()
 map_file = open(interface.mapping_filepath).read()
+# Using default mapping in modules/qradar/json/to_stix_map.json
 map_data = json.loads(map_file)
 data_source = {
     "type": "identity",
@@ -319,3 +320,64 @@ class TestTransform(object):
         assert('SHA-1' not in hashes), 'SHA-1 hash included'
         assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
         assert(hashes['SHA-256'] == 'someSHA-256hash')
+
+    def test_hashtype_lookup_without_matching_generic_hash_name(self):
+        data_source_string = json.dumps(data_source)
+
+        data = [{
+            "filehash": "unknownTypeHash",
+            "sha256hash": "someSHA-256hash",
+            "logsourceid": 123,
+            "filename": "someFile.exe"
+        }]
+
+        data_string = json.dumps(data)
+        options = {
+            "hash_options": {
+                "generic_name": "someUnknownHashName",
+                "log_source_id_map": {"2345": "sha-256", "65": "md5"}
+            }
+        }
+
+        translation = stix_translation.StixTranslation()
+        result = translation.translate('qradar', 'results', data_source_string, data_string, options)
+        result_bundle = json.loads(result)
+
+        result_bundle_objects = result_bundle['objects']
+        observed_data = result_bundle_objects[1]
+
+        assert('objects' in observed_data)
+        objects = observed_data['objects']
+
+        file_object = TestTransform.get_first_of_type(objects.values(), 'file')
+        assert(file_object is not None), 'file object not found'
+        hashes = file_object['hashes']
+        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
+
+    def test_hashtype_lookup_without_hash_options(self):
+        data_source_string = json.dumps(data_source)
+
+        data = [{
+            "filehash": "unknownTypeHash",
+            "sha256hash": "someSHA-256hash",
+            "logsourceid": 123,
+            "filename": "someFile.exe"
+        }]
+
+        data_string = json.dumps(data)
+        options = {}
+
+        translation = stix_translation.StixTranslation()
+        result = translation.translate('qradar', 'results', data_source_string, data_string, options)
+        result_bundle = json.loads(result)
+
+        result_bundle_objects = result_bundle['objects']
+        observed_data = result_bundle_objects[1]
+
+        assert('objects' in observed_data)
+        objects = observed_data['objects']
+
+        file_object = TestTransform.get_first_of_type(objects.values(), 'file')
+        assert(file_object is not None), 'file object not found'
+        hashes = file_object['hashes']
+        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'


### PR DESCRIPTION
Qradar maps its generic file hash column to the STIX attribute: `file.hashes.UNKNOWN`. This is done since the column needs to be represented in the mapping in order for it to get picked up for results-to-STIX translation, but it isn't know what type of hash it is. The QRadar module uses the log source id to attempt to match the hash with the proper hash type. If this lookup is successful, the UNKNOWN gets replaced with the proper hash type (i.e. SHA-256). There were cases where this lookup was failing and UNKNOWN was still showing up in the STIX file object. This PR fixes that.