### PR TITLE
fix: transform source and destination port to intergers

### DIFF
--- a/stix_shifter/stix_translation/src/modules/csa/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/csa/json/to_stix_map.json
@@ -102,11 +102,13 @@
   },
   "destinationport": {
     "key": "network-traffic.dst_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "sourceport": {
     "key": "network-traffic.src_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "protocol": {
     "key": "network-traffic.protocols",

--- a/stix_shifter/stix_translation/src/modules/dummy/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/dummy/json/to_stix_map.json
@@ -78,11 +78,13 @@
   },
   "dummyDestinationPortField": {
     "key": "network-traffic.dst_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "dummySourcePortField": {
     "key": "network-traffic.src_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "dummyNetworkProtocolField": {
     "key": "network-traffic.protocols",

--- a/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
@@ -119,11 +119,13 @@
   },
   "destinationport": {
     "key": "network-traffic.dst_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "sourceport": {
     "key": "network-traffic.src_port",
-    "object": "nt"
+    "object": "nt",
+    "transformer": "ToInteger"
   },
   "protocol": {
     "key": "network-traffic.protocols",

--- a/tests/stix_translation/test_qradar_json_to_stix.py
+++ b/tests/stix_translation/test_qradar_json_to_stix.py
@@ -63,7 +63,7 @@ class TestTransform(object):
         source_ip = "fd80:655e:171d:30d4:fd80:655e:171d:30d4"
         destination_ip = "255.255.255.1"
         file_name = "somefile.exe"
-        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": 3000, "destinationport": 2000, "filename": file_name, "domainname": url}
+        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": "3000", "destinationport": 2000, "filename": file_name, "domainname": url}
 
         result_bundle = json_to_stix_translator.convert_to_stix(
             data_source, map_data, [data], transformers.get_all_transformers(), options)


### PR DESCRIPTION
Some of the modules weren't applying the transformer in their results-to-stix mapping. This resulted in port numbers getting saved in the object as strings if that's how them came in from the data source.