### PR TITLE
Allow mac address objects to be referenced by network-traffic objects

### DIFF
--- a/stix_shifter/stix_translation/src/json_to_stix/json_to_stix_translator.py
+++ b/stix_shifter/stix_translation/src/json_to_stix/json_to_stix_translator.py
@@ -92,15 +92,27 @@ class DataSourceObjToStixObj:
         """
         obj_type, obj_prop = key_to_add.split('.', 1)
         objs_dir = observation['objects']
-        if obj_name in obj_name_map:
-            obj = objs_dir[obj_name_map[obj_name]]
+        if type(obj_name) is list:
+            for obj_name_index in obj_name:
+                if obj_name_index in obj_name_map:
+                    obj = objs_dir[obj_name_map[obj_name_index]]
+                else:
+                    obj = {'type': obj_type}
+                    obj_dir_key = str(len(objs_dir))
+                    objs_dir[obj_dir_key] = obj
+                    if obj_name_index is not None:
+                        obj_name_map[obj_name_index] = obj_dir_key
+                DataSourceObjToStixObj._add_property(obj, obj_prop, stix_value)
         else:
-            obj = {'type': obj_type}
-            obj_dir_key = str(len(objs_dir))
-            objs_dir[obj_dir_key] = obj
-            if obj_name is not None:
-                obj_name_map[obj_name] = obj_dir_key
-        DataSourceObjToStixObj._add_property(obj, obj_prop, stix_value)
+            if obj_name in obj_name_map:
+                obj = objs_dir[obj_name_map[obj_name]]
+            else:
+                obj = {'type': obj_type}
+                obj_dir_key = str(len(objs_dir))
+                objs_dir[obj_dir_key] = obj
+                if obj_name is not None:
+                    obj_name_map[obj_name] = obj_dir_key
+            DataSourceObjToStixObj._add_property(obj, obj_prop, stix_value)
 
     @staticmethod
     def _valid_stix_value(props_map, key, stix_value):

--- a/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
@@ -87,6 +87,28 @@
       "references": "src_ip"
     }
   ],
+  "sourcemac": [
+    {
+      "key": "mac-addr.value",
+      "object": "src_mac"
+    },
+    {
+      "key": "network-traffic.src_ref",
+      "object": "nt_mac",
+      "references": "src_mac"
+    }
+  ],
+  "destinationmac": [
+    {
+      "key": "mac-addr.value",
+      "object": "dst_mac"
+    },
+    {
+      "key": "network-traffic.dst_ref",
+      "object": "nt_mac",
+      "references": "dst_mac"
+    }
+  ],
   "qid": {
     "key": "x_com_ibm_ariel.qid",
     "cybox": false
@@ -119,17 +141,17 @@
   },
   "destinationport": {
     "key": "network-traffic.dst_port",
-    "object": "nt",
+    "object": ["nt","nt_mac"],
     "transformer": "ToInteger"
   },
   "sourceport": {
     "key": "network-traffic.src_port",
-    "object": "nt",
+    "object": ["nt","nt_mac"],
     "transformer": "ToInteger"
   },
   "protocol": {
     "key": "network-traffic.protocols",
-    "object": "nt",
+    "object": ["nt","nt_mac"],
     "transformer": "ToLowercaseArray"
   },
   "domainname": {


### PR DESCRIPTION
i closed the previous PR with same changes. created new one with restructured stix-shifter.