### PR TITLE
create query needs to use body params not url params.

### DIFF
--- a/stix_shifter/stix_transmission/src/modules/qradar/arielapiclient.py
+++ b/stix_shifter/stix_transmission/src/modules/qradar/arielapiclient.py
@@ -87,7 +87,7 @@ class APIClient():
         # to https://<server_ip>/api/ariel/searches
         endpoint = self.endpoint_start + "searches"
         data = {'query_expression': query_expression}
-        return self.client.call_api(endpoint, 'POST', urldata=data)
+        return self.client.call_api(endpoint, 'POST', data=data)
 
     def get_search(self, search_id):
         # Sends a GET request to


### PR DESCRIPTION
Trying:

```
python main.py transmit qradar '{"host":"1.1.1.1", "port":"443", "cert_verify": "False"}' '{"auth":{"SEC":"51c0767a-2465-4097-bb24-a9a6112e595c"}}' query "SELECT QIDNAME(qid) as qidname, qid as qid, CATEGORYNAME(category) as categoryname, category as categoryid, CATEGORYNAME(highlevelcategory) as high_level_category_name, highlevelcategory as high_level_category_id, logsourceid as logsourceid, LOGSOURCETYPENAME(logsourceid) as logsourcetypename, LOGSOURCENAME(logsourceid) as logsourcename, starttime as starttime, endtime as endtime, devicetime as devicetime, sourceaddress as sourceip, sourceport as sourceport, sourcemac as sourcemac, destinationaddress as destinationip, destinationport as destinationport, destinationmac as destinationmac, username as username, eventdirection as direction, identityip as identityip, identityhostname as identity_host_name, eventcount as eventcount, PROTOCOLNAME(protocolid) as protocol, BASE64(payload) as payload, URL as url, magnitude as magnitude, Filename as filename, URL as domainname FROM events WHERE (sourceip = '80.78.250.5' OR destinationip = '80.78.250.5' OR identityip = '80.78.250.5') OR (sourceip = '199.204.248.133' OR destinationip = '199.204.248.133' OR identityip = '199.204.248.133') OR (sourceip = '94.73.151.124' OR destinationip = '94.73.151.124' OR identityip = '94.73.151.124') OR (sourceip = '199.79.62.19' OR destinationip = '199.79.62.19' OR identityip = '199.79.62.19') OR (sourceip = '108.179.235.106' OR destinationip = '108.179.235.106' OR identityip = '108.179.235.106') OR (sourceip = '213.186.33.3' OR destinationip = '213.186.33.3' OR identityip = '213.186.33.3') OR (sourceip = '78.110.50.139' OR destinationip = '78.110.50.139' OR identityip = '78.110.50.139') OR (sourceip = '195.248.240.29' OR destinationip = '195.248.240.29' OR identityip = '195.248.240.29') OR (sourceip = '50.116.93.121' OR destinationip = '50.116.93.121' OR identityip = '50.116.93.121') OR (sourceip = '134.0.14.236' OR destinationip = '134.0.14.236' OR identityip = '134.0.14.236') OR (sourceip = '199.168.190.18' OR destinationip = '199.168.190.18' OR identityip = '199.168.190.18') OR (sourceip = '192.254.189.235' OR destinationip = '192.254.189.235' OR identityip = '192.254.189.235') OR (sourceip = '103.81.85.62' OR destinationip = '103.81.85.62' OR identityip = '103.81.85.62') OR (sourceip = '79.98.25.1' OR destinationip = '79.98.25.1' OR identityip = '79.98.25.1') OR (sourceip = '69.195.92.96' OR destinationip = '69.195.92.96' OR identityip = '69.195.92.96') OR (sourceip = '64.50.187.210' OR destinationip = '64.50.187.210' OR identityip = '64.50.187.210') OR (sourceip = '79.137.45.151' OR destinationip = '79.137.45.151' OR identityip = '79.137.45.151') OR (sourceip = '192.185.41.242' OR destinationip = '192.185.41.242' OR identityip = '192.185.41.242') OR (sourceip = '67.227.237.155' OR destinationip = '67.227.237.155' OR identityip = '67.227.237.155') OR (sourceip = '88.99.6.195' OR destinationip = '88.99.6.195' OR identityip = '88.99.6.195') OR (sourceip = '86.109.170.198' OR destinationip = '86.109.170.198' OR identityip = '86.109.170.198') OR (sourceip = '185.176.40.56' OR destinationip = '185.176.40.56' OR identityip = '185.176.40.56') OR (sourceip = '208.113.218.152' OR destinationip = '208.113.218.152' OR identityip = '208.113.218.152') OR (sourceip = '184.168.36.1' OR destinationip = '184.168.36.1' OR identityip = '184.168.36.1') OR (sourceip = '103.36.92.87' OR destinationip = '103.36.92.87' OR identityip = '103.36.92.87') OR (sourceip = '50.28.48.230' OR destinationip = '50.28.48.230' OR identityip = '50.28.48.230') OR (sourceip = '66.84.12.179' OR destinationip = '66.84.12.179' OR identityip = '66.84.12.179') OR (sourceip = '108.167.182.150' OR destinationip = '108.167.182.150' OR identityip = '108.167.182.150') OR (sourceip = '90.156.201.101' OR destinationip = '90.156.201.101' OR identityip = '90.156.201.101') OR (sourceip = '103.221.221.106' OR destinationip = '103.221.221.106' OR identityip = '103.221.221.106') OR (sourceip = '192.185.16.198' OR destinationip = '192.185.16.198' OR identityip = '192.185.16.198') OR (sourceip = '176.31.26.85' OR destinationip = '176.31.26.85' OR identityip = '176.31.26.85') OR (sourceip = '200.11.115.203' OR destinationip = '200.11.115.203' OR identityip = '200.11.115.203') OR (sourceip = '54.200.192.185' OR destinationip = '54.200.192.185' OR identityip = '54.200.192.185') OR (sourceip = '132.148.19.114' OR destinationip = '132.148.19.114' OR identityip = '132.148.19.114') OR (sourceip = '143.95.239.87' OR destinationip = '143.95.239.87' OR identityip = '143.95.239.87') OR (sourceip = '192.185.22.158' OR destinationip = '192.185.22.158' OR identityip = '192.185.22.158') OR (sourceip = '86.109.162.32' OR destinationip = '86.109.162.32' OR identityip = '86.109.162.32') OR (sourceip = '185.182.56.23' OR destinationip = '185.182.56.23' OR identityip = '185.182.56.23') OR (sourceip = '50.28.78.125' OR destinationip = '50.28.78.125' OR identityip = '50.28.78.125') OR (sourceip = '86.109.162.32' OR destinationip = '86.109.162.32' OR identityip = '86.109.162.32') OR (sourceip = '195.208.1.102' OR destinationip = '195.208.1.102' OR identityip = '195.208.1.102') OR (sourceip = '192.185.225.113' OR destinationip = '192.185.225.113' OR identityip = '192.185.225.113') OR (sourceip = '207.55.240.15' OR destinationip = '207.55.240.15' OR identityip = '207.55.240.15') OR (sourceip = '50.87.145.130' OR destinationip = '50.87.145.130' OR identityip = '50.87.145.130') OR (sourceip = '94.73.147.215' OR destinationip = '94.73.147.215' OR identityip = '94.73.147.215') OR (sourceip = '103.103.175.242' OR destinationip = '103.103.175.242' OR identityip = '103.103.175.242') OR (sourceip = '68.66.216.25' OR destinationip = '68.66.216.25' OR identityip = '68.66.216.25') OR (sourceip = '195.208.1.102' OR destinationip = '195.208.1.102' OR identityip = '195.208.1.102') OR (sourceip = '108.167.146.36' OR destinationip = '108.167.146.36' OR identityip = '108.167.146.36') OR (sourceip = '50.28.78.125' OR destinationip = '50.28.78.125' OR identityip = '50.28.78.125') OR (sourceip = '213.186.33.3' OR destinationip = '213.186.33.3' OR identityip = '213.186.33.3') OR (sourceip = '91.218.229.13' OR destinationip = '91.218.229.13' OR identityip = '91.218.229.13') OR (sourceip = '87.98.239.3' OR destinationip = '87.98.239.3' OR identityip = '87.98.239.3') OR (sourceip = '87.236.16.97' OR destinationip = '87.236.16.97' OR identityip = '87.236.16.97') OR (sourceip = '162.241.169.27' OR destinationip = '162.241.169.27' OR identityip = '162.241.169.27') OR (sourceip = '46.17.44.54' OR destinationip = '46.17.44.54' OR identityip = '46.17.44.54') OR (sourceip = '93.90.146.107' OR destinationip = '93.90.146.107' OR identityip = '93.90.146.107') OR (sourceip = '208.180.26.218' OR destinationip = '208.180.26.218' OR identityip = '208.180.26.218') OR (sourceip = '192.185.41.249' OR destinationip = '192.185.41.249' OR identityip = '192.185.41.249') OR (sourceip = '108.167.146.36' OR destinationip = '108.167.146.36' OR identityip = '108.167.146.36') OR (sourceip = '69.16.221.118' OR destinationip = '69.16.221.118' OR identityip = '69.16.221.118') OR (sourceip = '50.87.149.40' OR destinationip = '50.87.149.40' OR identityip = '50.87.149.40') OR (sourceip = '205.186.175.60' OR destinationip = '205.186.175.60' OR identityip = '205.186.175.60') OR (sourceip = '80.78.250.5' OR destinationip = '80.78.250.5' OR identityip = '80.78.250.5') OR (sourceip = '192.185.226.188' OR destinationip = '192.185.226.188' OR identityip = '192.185.226.188') OR (sourceip = '75.126.5.21' OR destinationip = '75.126.5.21' OR identityip = '75.126.5.21') OR (sourceip = '143.95.253.75' OR destinationip = '143.95.253.75' OR identityip = '143.95.253.75') OR (sourceip = '108.167.182.150' OR destinationip = '108.167.182.150' OR identityip = '108.167.182.150') OR (sourceip = '134.0.15.134' OR destinationip = '134.0.15.134' OR identityip = '134.0.15.134') OR (sourceip = '108.167.142.229' OR destinationip = '108.167.142.229' OR identityip = '108.167.142.229') OR (sourceip = '195.208.1.105' OR destinationip = '195.208.1.105' OR identityip = '195.208.1.105') OR (sourceip = '192.185.5.222' OR destinationip = '192.185.5.222' OR identityip = '192.185.5.222') OR (sourceip = '185.87.187.131' OR destinationip = '185.87.187.131' OR identityip = '185.87.187.131') OR (sourceip = '194.36.84.8' OR destinationip = '194.36.84.8' OR identityip = '194.36.84.8') OR (sourceip = '137.59.148.200' OR destinationip = '137.59.148.200' OR identityip = '137.59.148.200') OR (sourceip = '69.167.143.43' OR destinationip = '69.167.143.43' OR identityip = '69.167.143.43') OR (sourceip = '173.82.255.228' OR destinationip = '173.82.255.228' OR identityip = '173.82.255.228') OR (sourceip = '67.225.189.77' OR destinationip = '67.225.189.77' OR identityip = '67.225.189.77') OR (sourceip = '37.9.175.4' OR destinationip = '37.9.175.4' OR identityip = '37.9.175.4') OR (sourceip = '143.95.239.87' OR destinationip = '143.95.239.87' OR identityip = '143.95.239.87') OR (sourceip = '185.154.53.95' OR destinationip = '185.154.53.95' OR identityip = '185.154.53.95') OR (sourceip = '195.74.38.98' OR destinationip = '195.74.38.98' OR identityip = '195.74.38.98') OR (sourceip = '5.101.152.146' OR destinationip = '5.101.152.146' OR identityip = '5.101.152.146') OR (sourceip = '170.10.161.78' OR destinationip = '170.10.161.78' OR identityip = '170.10.161.78') OR (sourceip = '52.79.189.237' OR destinationip = '52.79.189.237' OR identityip = '52.79.189.237') OR (sourceip = '27.254.87.172' OR destinationip = '27.254.87.172' OR identityip = '27.254.87.172') OR (sourceip = '50.87.148.108' OR destinationip = '50.87.148.108' OR identityip = '50.87.148.108') OR (sourceip = '195.208.1.107' OR destinationip = '195.208.1.107' OR identityip = '195.208.1.107') OR (sourceip = '79.98.25.1' OR destinationip = '79.98.25.1' OR identityip = '79.98.25.1') OR (sourceip = '64.29.151.221' OR destinationip = '64.29.151.221' OR identityip = '64.29.151.221') OR (sourceip = '119.59.104.39' OR destinationip = '119.59.104.39' OR identityip = '119.59.104.39') OR (sourceip = '50.116.93.60' OR destinationip = '50.116.93.60' OR identityip = '50.116.93.60') OR (sourceip = '74.208.53.56' OR destinationip = '74.208.53.56' OR identityip = '74.208.53.56') OR (sourceip = '27.254.153.22' OR destinationip = '27.254.153.22' OR identityip = '27.254.153.22') OR (sourceip = '193.124.179.13' OR destinationip = '193.124.179.13' OR identityip = '193.124.179.13') OR (sourceip = '178.210.68.134' OR destinationip = '178.210.68.134' OR identityip = '178.210.68.134') OR (sourceip = '93.90.146.107' OR destinationip = '93.90.146.107' OR identityip = '93.90.146.107') OR (sourceip = '101.50.1.12' OR destinationip = '101.50.1.12' OR identityip = '101.50.1.12') OR (sourceip = '112.213.95.105' OR destinationip = '112.213.95.105' OR identityip = '112.213.95.105') OR (sourceip = '206.189.146.59' OR destinationip = '206.189.146.59' OR identityip = '206.189.146.59') OR (sourceip = '195.208.1.108' OR destinationip = '195.208.1.108' OR identityip = '195.208.1.108') OR (sourceip = '107.150.58.99' OR destinationip = '107.150.58.99' OR identityip = '107.150.58.99') limit 10000;"
```

will give
 Client Error: Request-URI Too Long for url

switched it to use body params and error goes away.