### PR TITLE
Dynamic mapping for fields for splunk.

### DIFF
--- a/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
@@ -4,6 +4,7 @@ import importlib
 from ...patterns.parser import generate_query
 from ..base.base_query_translator import BaseQueryTranslator
 from . import splunk_query_constructor
+from ..cim import cim_data_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -30,19 +31,24 @@ class StixToSplunk(BaseQueryTranslator):
         query_object = generate_query(data)
         data_mapper = options.get('data_mapper')
         mapping = options.get('mapping')
+        fields = options.get('fields')
 
         if not data_mapper:
             data_mapper = 'cim'
 
-        data_mapper_module_name = ''.join(["stix_shifter.stix_translation.src.modules.", data_mapper, ".", data_mapper, "_data_mapping"])
+        if data_mapper != 'cim':
+            data_mapper_module_name = ''.join(["stix_shifter.stix_translation.src.modules.", data_mapper, ".", data_mapper, "_data_mapping"])
 
-        try:
-            data_mapper_module = importlib.import_module(data_mapper_module_name)
-            data_model_mapper = data_mapper_module.mapper_class(mapping)
-        except ModuleNotFoundError:
-            raise NotImplementedError(f"Module {data_mapper_module_name} not implemented")
-        except AttributeError:
-            raise NotImplementedError(f"Module {data_mapper_module_name} does not implement mapper_class attribute")
+            try:
+                data_mapper_module = importlib.import_module(data_mapper_module_name)
+                data_model_mapper = data_mapper_module.mapper_class(mapping)
+            except ModuleNotFoundError:
+                raise NotImplementedError(f"Module {data_mapper_module_name} not implemented")
+            except AttributeError:
+                raise NotImplementedError(f"Module {data_mapper_module_name} does not implement mapper_class attribute")
+        else:
+            data_mapper_module = cim_data_mapping
+            data_model_mapper = data_mapper_module.mapper_class(mapping,fields)
 
         result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
         timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE

--- a/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
@@ -34,9 +34,9 @@ class StixToSplunk(BaseQueryTranslator):
         fields = options.get('fields')
 
         if not data_mapper:
-            data_mapper = 'cim'
-
-        if data_mapper != 'cim':
+            data_mapper_module = cim_data_mapping
+            data_model_mapper = data_mapper_module.mapper_class(mapping, fields)
+        else:
             data_mapper_module_name = ''.join(["stix_shifter.stix_translation.src.modules.", data_mapper, ".", data_mapper, "_data_mapping"])
 
             try:
@@ -46,9 +46,6 @@ class StixToSplunk(BaseQueryTranslator):
                 raise NotImplementedError(f"Module {data_mapper_module_name} not implemented")
             except AttributeError:
                 raise NotImplementedError(f"Module {data_mapper_module_name} does not implement mapper_class attribute")
-        else:
-            data_mapper_module = cim_data_mapping
-            data_model_mapper = data_mapper_module.mapper_class(mapping,fields)
 
         result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
         timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -172,10 +172,17 @@ class TestStixToSpl(unittest.TestCase, object):
                         "value": ["src_ip","dest_ip"]
                     }
                 }
-            }
+            },
+            "fields": {
+                "default":
+                    [
+                        "src_ip",
+                        "src_port",
+                    ]
+                }
         }
 
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
-        queries = 'search ((mac = "00-00-5E-00-53-00") AND ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-15minutes" | head 1000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
+        queries = 'search ((mac = "00-00-5E-00-53-00") AND ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-15minutes" | head 1000 | fields src_ip, src_port'
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert query == {'queries': queries, 'parsed_stix': parsed_stix}


### PR DESCRIPTION
Ex: 

```python main.py translate splunk query {} "[ipv4-addr:value = '58.218.66.97']" '{"fields":{"default":["src_port","src_ip"]}, "mapping": {"ipv4-addr":{ "cim_type": "flow","fields": { "value": ["source","dest"]}}}}'```