### PR TITLE
determine hashtype based on length for Qradar file hashes

### DIFF
--- a/stix_shifter/stix_translation/src/modules/qradar/json/from_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/qradar/json/from_stix_map.json
@@ -21,7 +21,10 @@
   },
   "file": {
     "fields": {
-      "name": ["filename"]
+      "name": ["filename"],
+      "hashes.SHA-256": ["filehash"],
+      "hashes.MD5": ["filehash"],
+      "hashes.SHA-1": ["filehash"]
     }
   },
   "network-traffic": {

--- a/stix_shifter/stix_translation/src/modules/qradar/qradar_utils.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/qradar_utils.py
@@ -2,28 +2,41 @@ class FileHashLookupException(Exception):
     pass
 
 
+def _find_hash_type_by_length(value):
+    HASH_LENGTH = {'40': 'sha-1', '64': 'sha-256', '32': 'md5'}
+    hash_type = HASH_LENGTH.get(str(len(value)), '')
+    if hash_type:
+        return "file.hashes.{}".format(hash_type.upper())
+    else:
+        return ''
+
+
+def _find_hash_type_by_logsource(obj, hash_options):
+    logsourceid = str(obj.get('logsourceid', ''))
+    log_source_id_map = hash_options.get('log_source_id_map', {})
+    if logsourceid and logsourceid in log_source_id_map:
+        hash_type = log_source_id_map.get(logsourceid)
+        return "file.hashes.{}".format(hash_type.upper())
+    else:
+        return ''
+
+
 def hash_type_lookup(obj, ds_key, mapped_stix_attribute, options):
     UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE = 'file.hashes.UNKNOWN'
+    STIX_HASH_TYPES = ['file.hashes.SHA-256', 'file.hashes.SHA-1', 'file.hashes.MD5', UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE]
+    if mapped_stix_attribute not in STIX_HASH_TYPES:
+        return ''
     hash_options = options.get('hash_options', {})
-    log_source_id_map = hash_options.get('log_source_id_map', {})
     generic_hash_name = hash_options.get('generic_name', '')
-    if not generic_hash_name or ds_key != generic_hash_name:
-        if mapped_stix_attribute == UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE:
-            raise FileHashLookupException("Generic hash type found that doesn't match generic name")
-        else:
-            # Current key is not generic hash, so return and let regular mapping resume
-            return ''
-    else:
+    if generic_hash_name and ds_key == generic_hash_name:
         generic_hash_value = obj[generic_hash_name]
         # These values must match with the aliases set in the select fields
         for type in ["sha256hash", "md5hash", "sha1hash"]:
             if type in obj and obj[type] == generic_hash_value:
                 raise FileHashLookupException("Generic hash value already exists in specific hash-type result")
-        # Determine hash type based on log source ID map
-        logsourceid = str(obj.get('logsourceid', ''))
-        if not logsourceid or logsourceid not in log_source_id_map:
-            raise FileHashLookupException('Unable to determine type of file hash based on log source ID.')
-        else:
-            hash_type = log_source_id_map.get(logsourceid)
-            hash_type = hash_type.upper()
-            return "file.hashes.{}".format(hash_type.upper())
+
+        return _find_hash_type_by_logsource(obj, hash_options) or _find_hash_type_by_length(obj.get(ds_key, ''))
+    elif mapped_stix_attribute == UNKNOWN_HASH_TYPE_STIX_ATTRIBUTE:
+        return _find_hash_type_by_length(obj.get(ds_key, ''))
+    else:
+        return ''

--- a/tests/stix_translation/test_qradar_json_to_stix.py
+++ b/tests/stix_translation/test_qradar_json_to_stix.py
@@ -66,7 +66,8 @@ class TestTransform(object):
         file_name = "somefile.exe"
         source_mac = "00-00-5E-00-53-00"
         destination_mac = "00-00-5A-00-55-01"
-        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP', "sourceport": "3000", "destinationport": 2000, "filename": file_name, "domainname": url, "sourcemac": source_mac, "destinationmac": destination_mac}
+        data = {"sourceip": source_ip, "destinationip": destination_ip, "url": url, "payload": payload, "username": user_id, "protocol": 'TCP',
+                "sourceport": "3000", "destinationport": 2000, "filename": file_name, "domainname": url, "sourcemac": source_mac, "destinationmac": destination_mac}
 
         result_bundle = json_to_stix_translator.convert_to_stix(
             data_source, map_data, [data], transformers.get_all_transformers(), options)
@@ -304,6 +305,7 @@ class TestTransform(object):
         assert('SHA-1' not in hashes), 'SHA-1 hash included'
         assert(hashes['SHA-256'] == 'someSHA-256hash')
         assert(hashes['MD5'] == 'unknownTypeHash')
+        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
 
     def test_hashtype_lookup_without_matching_logsource_id(self):
         data_source_string = json.dumps(data_source)
@@ -342,8 +344,9 @@ class TestTransform(object):
         assert('SHA-256' in hashes), 'SHA-256 hash not included'
         assert('MD5' not in hashes), 'MD5 hash included'
         assert('SHA-1' not in hashes), 'SHA-1 hash included'
-        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
+        assert('UNKNOWN' in hashes), 'UNKNOWN hash not included'
         assert(hashes['SHA-256'] == 'someSHA-256hash')
+        assert(hashes['UNKNOWN'] == 'unknownTypeHash')
 
     def test_hashtype_lookup_without_matching_generic_hash_name(self):
         data_source_string = json.dumps(data_source)
@@ -376,7 +379,8 @@ class TestTransform(object):
         file_object = TestTransform.get_first_of_type(objects.values(), 'file')
         assert(file_object is not None), 'file object not found'
         hashes = file_object['hashes']
-        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
+        assert('UNKNOWN' in hashes), 'UNKNOWN hash not included'
+        assert(hashes['UNKNOWN'] == 'unknownTypeHash')
 
     def test_hashtype_lookup_without_hash_options(self):
         data_source_string = json.dumps(data_source)
@@ -404,4 +408,27 @@ class TestTransform(object):
         file_object = TestTransform.get_first_of_type(objects.values(), 'file')
         assert(file_object is not None), 'file object not found'
         hashes = file_object['hashes']
-        assert('UNKNOWN' not in hashes), 'UNKNOWN hash included'
+        assert('UNKNOWN' in hashes), 'UNKNOWN hash not included'
+
+    def test_hashtype_lookup_by_length(self):
+        data_source_string = json.dumps(data_source)
+        hashes = {'SHA-256': '05503abea7b8ac0a01db3cb35179242c0c1d43c7002c51e5982318244bdcaba9',
+                  'SHA-1': '05503abea7b8ac0a01db3cb35179242c0c1d43c7',
+                  'MD5': '05503abea7b8ac0a01db3cb35179242c',
+                  'UNKNOWN': '05503abea'}
+        for key, value in hashes.items():
+            data = [{'filehash': value}]
+            data_string = json.dumps(data)
+            options = {}
+            translation = stix_translation.StixTranslation()
+            result = translation.translate('qradar', 'results', data_source_string, data_string, options)
+            result_bundle = json.loads(result)
+
+            result_bundle_objects = result_bundle['objects']
+            observed_data = result_bundle_objects[1]
+            objects = observed_data['objects']
+
+            file_object = TestTransform.get_first_of_type(objects.values(), 'file')
+            hashes = file_object['hashes']
+            assert(key in hashes), "{} hash not included".format(key)
+            assert(hashes[key] == value)


### PR DESCRIPTION
Qradar module update to try and determine file hash type based on length if the type can't be matched to the log source id. This happens for hashes that come in from the "filehash" column.
Undetermined hash types will now be stored in the STIX file object with a key of "UNKNOWN"