### PR TITLE
Need to make sure we return an empty list for our pipeline.

### DIFF
--- a/stix_shifter/stix_transmission/src/modules/splunk/splunk_results_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/splunk/splunk_results_connector.py
@@ -12,11 +12,12 @@ class SplunkResultsConnector(BaseResultsConnector):
         try:
             response = self.api_client.get_search_results(search_id, offset, length)
             response_code = response.code
-            response_json = json.load(response) 
+            response_json = json.load(response)
+
             if "results" in response_json:
-                results = [{}] if (response_json['results'] == []) else response_json['results']
+                results = [] if (response_json['results'] == []) else response_json['results']
             else:
-                results = [{}]
+                results = []
 
             # Construct a response object
             return_obj = dict()

--- a/stix_shifter/stix_transmission/src/modules/splunk/splunk_results_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/splunk/splunk_results_connector.py
@@ -13,15 +13,13 @@ class SplunkResultsConnector(BaseResultsConnector):
             response = self.api_client.get_search_results(search_id, offset, length)
             response_code = response.code
             response_json = json.load(response)
-
-            if "results" in response_json:
-                results = [] if (response_json['results'] == []) else response_json['results']
-            else:
-                results = []
-
             # Construct a response object
             return_obj = dict()
             if response_code == 200:
+                if "results" in response_json:
+                    results = [] if (response_json['results'] == []) else response_json['results']
+                else:
+                    results = []
                 return_obj['success'] = True
                 return_obj['data'] = results
             else:

--- a/tests/stix_transmission/splunk/api_response/empty_result_by_sid.json
+++ b/tests/stix_transmission/splunk/api_response/empty_result_by_sid.json
@@ -1,0 +1,66 @@
+{
+    "preview": false,
+    "init_offset": 0,
+    "messages": [],
+    "fields": [
+        {
+            "name": "tag"
+        },
+        {
+            "name": "_bkt"
+        },
+        {
+            "name": "_cd"
+        },
+        {
+            "name": "_eventtype_color"
+        },
+        {
+            "name": "_indextime"
+        },
+        {
+            "name": "_raw"
+        },
+        {
+            "name": "_serial"
+        },
+        {
+            "name": "_si"
+        },
+        {
+            "name": "_sourcetype"
+        },
+        {
+            "name": "_time"
+        },
+        {
+            "name": "bytes"
+        },
+        {
+            "name": "dest_ip"
+        },
+        {
+            "name": "dest_port"
+        },
+        {
+            "name": "event_count"
+        },
+        {
+            "name": "log_type"
+        },
+        {
+            "name": "src_ip"
+        },
+        {
+            "name": "src_port"
+        },
+        {
+            "name": "transport"
+        },
+        {
+            "name": "user"
+        }
+    ],
+    "results": [],
+    "highlighted": {}
+}

--- a/tests/stix_transmission/splunk/test_class.py
+++ b/tests/stix_transmission/splunk/test_class.py
@@ -231,6 +231,39 @@ class TestSplunkConnection(unittest.TestCase, object):
 
     @patch('stix_shifter.stix_transmission.src.modules.splunk.spl_api_client.APIClient.get_search_results',
            autospec=True)
+    def test_results_response_empty_list(self, mock_results_response, mock_api_client):
+        mock_api_client.return_value = None
+
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(dir_path, 'api_response', 'empty_result_by_sid.json')
+        mocked_return_value = open(file_path, 'r').read()
+
+        mock_results_response.return_value = SplunkMockResponse(200, mocked_return_value)
+
+        module = splunk_connector
+        config = {
+            "auth": {
+                "username": "",
+                "password": ""
+            }
+        }
+        connection = {
+            "host": "host",
+            "port": "8080"
+        }
+
+        search_id = "1536832140.4293"
+        offset = 0
+        length = 1
+        results_response = module.Connector(connection, config).create_results_connection(search_id, offset, length)
+
+        assert 'success' in results_response
+        assert results_response['success'] is True
+        assert 'data' in results_response
+        assert len(results_response['data']) == 0
+
+    @patch('stix_shifter.stix_transmission.src.modules.splunk.spl_api_client.APIClient.get_search_results',
+           autospec=True)
     def test_results_response_exception(self, mock_results_response, mock_api_client):
         mock_api_client.return_value = None
 


### PR DESCRIPTION
An empty json object will still generate identity information.