### PR TITLE
Handle error when translating for unsupported data source

### DIFF
--- a/stix_shifter/stix_translation/src/exceptions.py
+++ b/stix_shifter/stix_translation/src/exceptions.py
@@ -1,2 +1,15 @@
 class DataMappingException(Exception):
     pass
+
+
+class StixValidationException(Exception):
+    pass
+
+
+class TranslationResultException(Exception):
+    def __str__(self):
+        return "Error when converting results to STIX"
+
+
+class UnsupportedDataSourceException(Exception):
+    pass

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -12,19 +12,6 @@ RESULTS = 'results'
 QUERY = 'query'
 
 
-# class StixValidationException(Exception):
-#     pass
-
-
-# class TranslationResultException(Exception):
-#     def __str__(self):
-#         return "Error when converting results to STIX"
-
-
-# class UnsupportedDataSourceException(Exception):
-#     pass
-
-
 class StixTranslation:
     """
     StixShifter class - implements translations of stix data

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -3,8 +3,8 @@ from stix_shifter.stix_translation.src.patterns.parser import generate_query
 from stix2patterns.validator import run_validator
 from stix_shifter.stix_translation.src.stix_pattern_parser import parse_stix
 import re
-import json
 from ..utils.error_response import ErrorResponder
+from .src.exceptions import DataMappingException, StixValidationException, UnsupportedDataSourceException, TranslationResultException
 
 
 TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bigfix', 'csa', 'csa:at', 'csa:nf', 'aws_security_hub', 'carbonblack']
@@ -12,12 +12,17 @@ RESULTS = 'results'
 QUERY = 'query'
 
 
-class StixValidationException(Exception):
-    pass
+# class StixValidationException(Exception):
+#     pass
 
-class TranslationResultException(Exception):
-    def __str__(self):
-        return "Error when converting results to STIX"
+
+# class TranslationResultException(Exception):
+#     def __str__(self):
+#         return "Error when converting results to STIX"
+
+
+# class UnsupportedDataSourceException(Exception):
+#     pass
 
 
 class StixTranslation:
@@ -48,18 +53,18 @@ class StixTranslation:
         if len(mod_dia) > 1:
             dialect = mod_dia[1]
 
-        if module not in TRANSLATION_MODULES:
-            raise NotImplementedError
-
-        translator_module = importlib.import_module(
-            "stix_shifter.stix_translation.src.modules." + module + "." + module + "_translator")
-
-        if dialect is not None:
-            interface = translator_module.Translator(dialect=dialect)
-        else:
-            interface = translator_module.Translator()
-
         try:
+            if module not in TRANSLATION_MODULES:
+                raise UnsupportedDataSourceException("{} is an unsupported data source.".format(module))
+
+            translator_module = importlib.import_module(
+                "stix_shifter.stix_translation.src.modules." + module + "." + module + "_translator")
+
+            if dialect is not None:
+                interface = translator_module.Translator(dialect=dialect)
+            else:
+                interface = translator_module.Translator()
+
             if translate_type == QUERY:
                 errors = []
                 # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format

--- a/stix_shifter/stix_translation/stix_translation_error_mapper.py
+++ b/stix_shifter/stix_translation/stix_translation_error_mapper.py
@@ -1,17 +1,17 @@
 from ..utils.error_mapper_base import ErrorMapperBase
 from ..utils.error_response import ErrorCode
-from .src.exceptions import DataMappingException
-from ..stix_translation.stix_translation import StixValidationException
+from .src.exceptions import DataMappingException, StixValidationException, UnsupportedDataSourceException, TranslationResultException
 from .src.patterns.errors import SearchFeatureNotSupportedError
-from ..stix_translation.stix_translation import TranslationResultException
 
 error_mapping = {
     NotImplementedError.__name__: ErrorCode.TRANSLATION_NOTIMPLEMENTED_MODE,
     DataMappingException.__name__: ErrorCode.TRANSLATION_MAPPING_ERROR,
     StixValidationException.__name__: ErrorCode.TRANSLATION_STIX_VALIDATION,
     SearchFeatureNotSupportedError.__name__: ErrorCode.TRANSLATION_NOTSUPPORTED,
-    TranslationResultException.__name__: ErrorCode.TRANSLATION_RESULT
-    }
+    TranslationResultException.__name__: ErrorCode.TRANSLATION_RESULT,
+    UnsupportedDataSourceException.__name__: ErrorCode.TRANSLATION_NOTIMPLEMENTED_MODE
+}
+
 
 class ErrorMapper():
 
@@ -19,7 +19,7 @@ class ErrorMapper():
 
     @staticmethod
     def set_error_code(data_dict, return_obj):
-        exception = None        
+        exception = None
         if 'exception' in data_dict:
             exception = data_dict['exception']
 

--- a/tests/stix_translation/test_translation_input.py
+++ b/tests/stix_translation/test_translation_input.py
@@ -1,0 +1,26 @@
+from stix_shifter.stix_translation import stix_translation
+import json
+
+data_source = {
+    "type": "identity",
+    "id": "identity--3532c56d-ea72-48be-a2ad-1a53f4c9c6d3",
+    "name": "unsupportedDataSource",
+    "identity_class": "events"
+}
+
+data = {"key": "value"}
+
+data_source_string = json.dumps(data_source)
+data_string = json.dumps(data)
+translation = stix_translation.StixTranslation()
+
+
+class TestTranslation(object):
+
+    def test_unsupported_datasource_for_results(self):
+        result = translation.translate('unsupportedDataSource', 'results', data_source_string, data_string)
+        assert result == {'code': 100, 'error': 'unsupportedDataSource is an unsupported data source.', 'success': False}
+
+    def test_unsupported_datasource_for_query(self):
+        result = translation.translate('unsupportedDataSource', 'query', '{}', "[ipv4-addr:value = '333.333.333.0']")
+        assert result == {'code': 100, 'error': 'unsupportedDataSource is an unsupported data source.', 'success': False}


### PR DESCRIPTION
Return error and code when unsupported data source is passed into the translation call. 