### PR TITLE
Recursion fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ def __main__():
     translate_parser.add_argument(
         'data', type=str, help='The STIX pattern or JSON results to be translated')
     translate_parser.add_argument('options', nargs='?', help='Options dictionary')
+    translate_parser.add_argument('recursion_limit', type=int, help='Maximum depth of Python interpreter stack')
 
     # optional arguments
     translate_parser.add_argument('-x', '--stix-validator', action='store_true',
@@ -187,10 +188,10 @@ def __main__():
             options['stix_validator'] = args.stix_validator
         if args.data_mapper:
             options['data_mapper'] = args.data_mapper
-
+        recursion_limit = args.recursion_limit if args.recursion_limit else 1000
         translation = stix_translation.StixTranslation()
         result = translation.translate(
-            args.module, args.translate_type, args.data_source, args.data, options=options)
+            args.module, args.translate_type, args.data_source, args.data, options=options, recursion_limit=recursion_limit)
     elif args.command == TRANSMIT:
         result = transmit(args)  # stix_transmission
 

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -12,7 +12,6 @@ TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bi
 RESULTS = 'results'
 QUERY = 'query'
 # Increase Python recursion limit so ANTLR doesn't choke an big patterns
-RECURSION_LIMIT = 10000
 
 
 class StixTranslation:
@@ -23,7 +22,7 @@ class StixTranslation:
     def __init__(self):
         self.args = []
 
-    def translate(self, module, translate_type, data_source, data, options={}):
+    def translate(self, module, translate_type, data_source, data, options={}, recursion_limit=1000):
         """
         Translated queries to a specified format
         :param module: What module to use
@@ -34,6 +33,8 @@ class StixTranslation:
         :type data: str
         :param options: translation options { stix_validator: bool }
         :type options: dict
+        :param recursion_limit: maximum depth of Python interpreter stack
+        :type recursion_limit: int
         :return: translated results
         :rtype: str
         """
@@ -57,7 +58,10 @@ class StixTranslation:
 
             if translate_type == QUERY:
                 # Increase the python recursion limit to allow ANTLR to parse large patterns
-                sys.setrecursionlimit(RECURSION_LIMIT)
+                current_recursion_limit = sys.getrecursionlimit()
+                if current_recursion_limit < recursion_limit:
+                    print("Changing Python recursion limit from {} to {}".format(current_recursion_limit, recursion_limit))
+                    sys.setrecursionlimit(recursion_limit)
                 errors = []
                 # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
                 start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'\sSTOP"

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -5,11 +5,14 @@ from stix_shifter.stix_translation.src.stix_pattern_parser import parse_stix
 import re
 from ..utils.error_response import ErrorResponder
 from .src.exceptions import DataMappingException, StixValidationException, UnsupportedDataSourceException, TranslationResultException
+import sys
 
 
 TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bigfix', 'csa', 'csa:at', 'csa:nf', 'aws_security_hub', 'carbonblack']
 RESULTS = 'results'
 QUERY = 'query'
+# Increase Python recursion limit so ANTLR doesn't choke an big patterns
+RECURSION_LIMIT = 2000
 
 
 class StixTranslation:
@@ -53,6 +56,8 @@ class StixTranslation:
                 interface = translator_module.Translator()
 
             if translate_type == QUERY:
+                # Increase the python recursion limit to allow ANTLR to parse large patterns
+                sys.setrecursionlimit(RECURSION_LIMIT)
                 errors = []
                 # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
                 start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'\sSTOP"

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -11,7 +11,6 @@ import sys
 TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bigfix', 'csa', 'csa:at', 'csa:nf', 'aws_security_hub', 'carbonblack']
 RESULTS = 'results'
 QUERY = 'query'
-# Increase Python recursion limit so ANTLR doesn't choke an big patterns
 
 
 class StixTranslation:

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -12,7 +12,7 @@ TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bi
 RESULTS = 'results'
 QUERY = 'query'
 # Increase Python recursion limit so ANTLR doesn't choke an big patterns
-RECURSION_LIMIT = 2000
+RECURSION_LIMIT = 10000
 
 
 class StixTranslation:


### PR DESCRIPTION
Increases the recursion depth limit of python to 10,000 so Antlr doesn't choke on large patterns. Tested with a pattern containing around 2000 ORs and 1000 observatios (square brackets). 