### PR TITLE
Timerange return

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ six==1.11.0
 wrapt==1.10.11
 requests==2.20.1
 flask==1.0.2
+freezegun==0.3.11

--- a/stix_shifter/stix_translation/src/modules/bigfix/bigfix_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/bigfix/bigfix_query_constructor.py
@@ -6,6 +6,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class RelevanceQueryStringPatternTranslator:
     comparator_lookup = {
         ComparisonExpressionOperators.And: "AND",
@@ -14,12 +15,12 @@ class RelevanceQueryStringPatternTranslator:
         ComparisonComparators.NotEqual: "!=",
         ComparisonComparators.Like: "contains",
         ObservationOperators.Or: 'OR',
-        # Treat AND's as OR's -- Unsure how two ObsExps wouldn't cancel each other out.  
+        # Treat AND's as OR's -- Unsure how two ObsExps wouldn't cancel each other out.
         ObservationOperators.And: 'OR'
     }
 
     query_format = {
-        "all_files_in_directory": "(\"file\", name of it | \"n/a\", \"sha256\", sha256 of it | \"n/a\", \"sha1\", sha1 of it | \"n/a\", \"md5\", md5 of it | \"n/a\", pathname of it | \"n/a\", (modification time of it - \"01 Jan 1970 00:00:00 +0000\" as time)/second ) of files of folder (\"{file_path}\")",        
+        "all_files_in_directory": "(\"file\", name of it | \"n/a\", \"sha256\", sha256 of it | \"n/a\", \"sha1\", sha1 of it | \"n/a\", \"md5\", md5 of it | \"n/a\", pathname of it | \"n/a\", (modification time of it - \"01 Jan 1970 00:00:00 +0000\" as time)/second ) of files of folder (\"{file_path}\")",
         "file_query": "(\"file\", name of it | \"n/a\", \"sha256\", sha256 of it | \"n/a\", \"sha1\", sha1 of it | \"n/a\", \"md5\", md5 of it | \"n/a\", pathname of it | \"n/a\", (modification time of it - \"01 Jan 1970 00:00:00 +0000\" as time)/second ) of files whose ({stix_object} of it as lowercase {object_value} as lowercase) of folder (\"{file_path}\")",
         "file_name_with_hash": "(\"file\", name of it | \"n/a\", \"sha256\", sha256 of it | \"n/a\", \"sha1\", sha1 of it | \"n/a\", \"md5\", md5 of it | \"n/a\", pathname of it | \"n/a\", (modification time of it - \"01 Jan 1970 00:00:00 +0000\" as time)/second ) of files whose ({name_object} of it as lowercase {file_name} as lowercase {expression_operator} {hash_type} of it as lowercase {hash_value} as lowercase) of folder (\"{file_path}\")",
         "all_processes": "( \"process\", name of it | \"n/a\", process id of it as string | \"n/a\", \"sha256\", sha256 of image file of it | \"n/a\", \"sha1\", sha1 of image file of it | \"n/a\", \"md5\", md5 of image file of it | \"n/a\", pathname of image file of it | \"n/a\", (start time of it - \"01 Jan 1970 00:00:00 +0000\" as time)/second ) of processes",
@@ -36,15 +37,14 @@ class RelevanceQueryStringPatternTranslator:
         self.result_limit = result_limit
         self.translated = self.parse_expression(pattern)
         self.queries = self.translated
-        
-    
+
     @staticmethod
     def _escape_value(value, comparator=None) -> str:
         if isinstance(value, str):
             return '{}'.format(value.replace('\\', '\\\\').replace('\"', '\\"').replace('(', '\\(').replace(')', '\\)'))
         else:
             return value
-    
+
     def _parse_expression(self, expression, qualifier=None):
         if isinstance(expression, ComparisonExpression):  # Base Case
              # Resolve STIX Object Path to a field in the target Data Model
@@ -63,16 +63,16 @@ class RelevanceQueryStringPatternTranslator:
 
             if stix_remainings == 'parent_directory_ref.path':
                 reference_property = 'folder'
-                self.query_string.update({reference_property:value})
+                self.query_string.update({reference_property: value})
             else:
                 if stix_key != "":
                     reference_property = stix_key
-                    self.query_string.update({stix_property:stix_key})
-                    self.query_string.update({'value':final_value})
+                    self.query_string.update({stix_property: stix_key})
+                    self.query_string.update({'value': final_value})
                 else:
-                    self.query_string.update({stix_object:final_value})
+                    self.query_string.update({stix_object: final_value})
 
-            self.query_string.update({'comparator':comparator})
+            self.query_string.update({'comparator': comparator})
 
             return self.query_string
         elif isinstance(expression, CombinedComparisonExpression):
@@ -80,11 +80,11 @@ class RelevanceQueryStringPatternTranslator:
             expression_operator = self.comparator_lookup[expression.operator]
             self._parse_expression(expression.expr2)
 
-            self.query_string.update({'expression_operator':expression_operator})
+            self.query_string.update({'expression_operator': expression_operator})
 
             if qualifier is not None:
                 logger.info("Qualifier is not supported in BigFix relevance query.")
-            
+
             return self.query_string
         elif isinstance(expression, ObservationExpression):
             return self._parse_expression(expression.comparison_expression, qualifier)
@@ -97,11 +97,14 @@ class RelevanceQueryStringPatternTranslator:
     def parse_expression(self, pattern: Pattern):
         return self._parse_expression(pattern)
 
-def translate_pattern(pattern: Pattern, result_limit, timerange=None):
+
+def translate_pattern(pattern: Pattern, options):
+    result_limit = options['result_limit']
+    # timerange = options['timerange']
     query_dictionary = {}
     translated_dictionary = RelevanceQueryStringPatternTranslator(pattern, result_limit)
     query_dictionary = translated_dictionary.queries
-    
+
     format_type = ""
     final_query = ""
     name_object = 'name'
@@ -114,7 +117,7 @@ def translate_pattern(pattern: Pattern, result_limit, timerange=None):
     if hash_object in query_dictionary:
         hash_type = query_dictionary.get(hash_object)
         if '-' in hash_type:
-            hash_type = hash_type.replace('-','').lower()
+            hash_type = hash_type.replace('-', '').lower()
 
     if file_object in query_dictionary:
         if file_object in query_dictionary and hash_object in query_dictionary and directory_alias in query_dictionary:
@@ -122,18 +125,19 @@ def translate_pattern(pattern: Pattern, result_limit, timerange=None):
             path_value = query_dictionary.get(directory_alias)
             hash_value = query_dictionary.get(value_object)
             format_type = 'file_name_with_hash'
-            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(name_object=name_object,file_name=file_name,expression_operator=query_dictionary.get('expression_operator'),hash_type=hash_type,hash_value=hash_value,file_path=path_value)
+            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(name_object=name_object, file_name=file_name,
+                                                                                                     expression_operator=query_dictionary.get('expression_operator'), hash_type=hash_type, hash_value=hash_value, file_path=path_value)
         elif hash_object in query_dictionary and directory_alias in query_dictionary:
             path_value = query_dictionary.get(directory_alias)
             hash_value = query_dictionary.get(value_object)
             format_type = 'file_query'
-            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=hash_type,object_value=hash_value,file_path=path_value)
+            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=hash_type, object_value=hash_value, file_path=path_value)
         elif hash_object not in query_dictionary:
             file_name = query_dictionary.get(file_object)
             path_value = query_dictionary.get(directory_alias)
             if "*" not in file_name:
                 format_type = 'file_query'
-                final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=name_object,object_value=file_name,file_path=path_value)
+                final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=name_object, object_value=file_name, file_path=path_value)
             else:
                 format_type = 'all_files_in_directory'
                 final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(file_path=path_value)
@@ -142,32 +146,33 @@ def translate_pattern(pattern: Pattern, result_limit, timerange=None):
         if hash_object not in query_dictionary:
             if "*" not in process_name:
                 format_type = 'filter_processes_with_name'
-                final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(process_object=name_object,process_name=process_name)
+                final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(process_object=name_object, process_name=process_name)
             else:
                 format_type = 'all_processes'
                 final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type)
         else:
             hash_value = query_dictionary.get(value_object)
             format_type = 'process_name_with_hash'
-            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(process_object=name_object,process_name=process_name,expression_operator=query_dictionary.get('expression_operator'), hash_type=hash_type,hash_value=hash_value)
+            final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(process_object=name_object, process_name=process_name,
+                                                                                                     expression_operator=query_dictionary.get('expression_operator'), hash_type=hash_type, hash_value=hash_value)
     elif hash_object in query_dictionary and directory_alias in query_dictionary:
         path_value = query_dictionary.get(directory_alias)
         hash_value = query_dictionary.get(value_object)
         format_type = 'file_query'
-        final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=hash_type,object_value=hash_value,file_path=path_value)
+        final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(stix_object=hash_type, object_value=hash_value, file_path=path_value)
     elif hash_object in query_dictionary:
         hash_value = query_dictionary.get(value_object)
         format_type = 'process_hash_query'
-        final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(hash_type=hash_type,hash_value=hash_value)
+        final_query = RelevanceQueryStringPatternTranslator.query_format.get(format_type).format(hash_type=hash_type, hash_value=hash_value)
     else:
         logger.info('Unable to translate the Stix pattern into Relevance query')
-        
+
         return 'Unable to translate the Stix pattern into Relevance query'
-    
+
     besapi_query = '<BESAPI xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"BESAPI.xsd\"><ClientQuery><ApplicabilityRelevance>true</ApplicabilityRelevance><QueryText>' + \
-            final_query + '</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
-    
-    # Clearing out the query dictionary as we no longer need. 
+        final_query + '</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
+
+    # Clearing out the query dictionary as we no longer need.
     RelevanceQueryStringPatternTranslator.query_string.clear()
-    
+
     return besapi_query

--- a/stix_shifter/stix_translation/src/modules/bigfix/stix_to_bigfix.py
+++ b/stix_shifter/stix_translation/src/modules/bigfix/stix_to_bigfix.py
@@ -26,9 +26,11 @@ class StixToRelevanceQuery(BaseQueryTranslator):
         logger.info("Converting STIX2 Pattern to Relevance language")
 
         query_object = generate_query(data)
-        result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
-        timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE
+        if 'result_limit' not in options:
+            options['result_limit'] = DEFAULT_LIMIT
+        if 'timerange' not in options:
+            options['timerange'] = DEFAULT_TIMERANGE
         query_string = bigfix_query_constructor.translate_pattern(
-            query_object, result_limit, timerange)
+            query_object, options)
 
         return query_string

--- a/stix_shifter/stix_translation/src/modules/bigfix/stix_to_bigfix.py
+++ b/stix_shifter/stix_translation/src/modules/bigfix/stix_to_bigfix.py
@@ -6,9 +6,6 @@ from . import bigfix_query_constructor
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
-
 
 class StixToRelevanceQuery(BaseQueryTranslator):
 
@@ -26,10 +23,6 @@ class StixToRelevanceQuery(BaseQueryTranslator):
         logger.info("Converting STIX2 Pattern to Relevance language")
 
         query_object = generate_query(data)
-        if 'result_limit' not in options:
-            options['result_limit'] = DEFAULT_LIMIT
-        if 'timerange' not in options:
-            options['timerange'] = DEFAULT_TIMERANGE
         query_string = bigfix_query_constructor.translate_pattern(
             query_object, options)
 

--- a/stix_shifter/stix_translation/src/modules/carbonblack/carbonblack_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/carbonblack/carbonblack_query_constructor.py
@@ -24,7 +24,7 @@ class CbQueryStringPatternTranslator:
         ComparisonComparators.LessThanOrEqual: ":",
 
         ObservationOperators.Or: 'or',
-        ObservationOperators.And: 'or', # This is technically wrong. It should be converted to two separate queries, but
+        ObservationOperators.And: 'or',  # This is technically wrong. It should be converted to two separate queries, but
         # current behavior of existing modules treat operator as an OR.
         # observation operator AND - both sides MUST evaluate to true on different observations to be true
     }
@@ -81,7 +81,7 @@ class CbQueryStringPatternTranslator:
             stripped = stripped.split('.', 1)[0]
         return stripped
 
-    def _format_start_stop_qualifier(self, expression, dialect, qualifier : StartStopQualifier) -> str:
+    def _format_start_stop_qualifier(self, expression, dialect, qualifier: StartStopQualifier) -> str:
         start = self._to_cb_timestamp(qualifier.start)
         stop = self._to_cb_timestamp(qualifier.stop)
 
@@ -101,19 +101,19 @@ class CbQueryStringPatternTranslator:
             pass
         elif len(process_queries) == 1:
             process_query = process_queries[0]
-            results.append({"query": process_query, "dialect":"process"})
+            results.append({"query": process_query, "dialect": "process"})
         else:
             process_query = "({})".format(") or (".join(process_queries))
-            results.append({"query": process_query, "dialect":"process"})
+            results.append({"query": process_query, "dialect": "process"})
 
         if len(binary_queries) == 0:
             pass
         elif len(binary_queries) == 1:
             binary_query = binary_queries[0]
-            results.append({"query": binary_query, "dialect":"binary"})
+            results.append({"query": binary_query, "dialect": "binary"})
         else:
             binary_query = "({})".format(") or (".join(binary_queries))
-            results.append({"query": binary_query, "dialect":"binary"})
+            results.append({"query": binary_query, "dialect": "binary"})
 
         return results
 
@@ -159,7 +159,6 @@ class CbQueryStringPatternTranslator:
         else:
             print(type(expression), expression)
             assert False
-
 
     # the return type of this function is a string for expressions types up to CombinedComparionExpression
     # for expressions of ObservableExpression or Higher in the grammar the return type is a list of dictionaries
@@ -247,6 +246,8 @@ class CbQueryStringPatternTranslator:
         return self._parse_expression(pattern)
 
 
-def translate_pattern(pattern: Pattern, data_model_mapping, result_limit, timerange=None):
+def translate_pattern(pattern: Pattern, data_model_mapping, options):
+    result_limit = options['result_limit']
+    # timerange = options['timerange']
     translated_statements = CbQueryStringPatternTranslator(pattern, data_model_mapping, result_limit)
     return translated_statements.queries

--- a/stix_shifter/stix_translation/src/modules/carbonblack/stix_to_cb.py
+++ b/stix_shifter/stix_translation/src/modules/carbonblack/stix_to_cb.py
@@ -28,8 +28,10 @@ class StixToCB(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = carbonblack_data_mapping.CarbonBlackDataMapper(options)
-        result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
-        timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE
+        if 'result_limit' not in options:
+            options['result_limit'] = DEFAULT_LIMIT
+        if 'timerange' not in options:
+            options['timerange'] = DEFAULT_TIMERANGE
         query_string = carbonblack_query_constructor.translate_pattern(
-            query_object, data_model_mapper, result_limit, timerange=timerange)
+            query_object, data_model_mapper, options)
         return query_string

--- a/stix_shifter/stix_translation/src/modules/carbonblack/stix_to_cb.py
+++ b/stix_shifter/stix_translation/src/modules/carbonblack/stix_to_cb.py
@@ -7,9 +7,6 @@ from . import carbonblack_query_constructor
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
-
 
 class StixToCB(BaseQueryTranslator):
 
@@ -28,10 +25,6 @@ class StixToCB(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = carbonblack_data_mapping.CarbonBlackDataMapper(options)
-        if 'result_limit' not in options:
-            options['result_limit'] = DEFAULT_LIMIT
-        if 'timerange' not in options:
-            options['timerange'] = DEFAULT_TIMERANGE
         query_string = carbonblack_query_constructor.translate_pattern(
             query_object, data_model_mapper, options)
         return query_string

--- a/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
@@ -214,7 +214,10 @@ class QueryStringPatternTranslator:
         return self._parse_expression(pattern)
 
 
-def translate_pattern(pattern: Pattern, data_model_mapping):
+def translate_pattern(pattern: Pattern, data_model_mapping, options):
+    # Query result limit and time range can be passed into the QueryStringPatternTranslator if supported by the data source.
+    # result_limit = options['result_limit']
+    # timerange = options['timerange']
     query = QueryStringPatternTranslator(pattern, data_model_mapping).translated
     # Add space around START STOP qualifiers
     query = re.sub("START", "START ", query)

--- a/stix_shifter/stix_translation/src/modules/dummy/stix_to_query.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/stix_to_query.py
@@ -7,6 +7,9 @@ from . import query_constructor
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
+
 
 class StixToQuery(BaseQueryTranslator):
 
@@ -26,6 +29,11 @@ class StixToQuery(BaseQueryTranslator):
         query_object = generate_query(data)
         data_model_mapper = data_mapping.DataMapper(options)
 
+        if 'result_limit' not in options:
+            options['result_limit'] = DEFAULT_LIMIT
+        if 'timerange' not in options:
+            options['timerange'] = DEFAULT_TIMERANGE
+
         query_string = query_constructor.translate_pattern(
-            query_object, data_model_mapper)
+            query_object, data_model_mapper, options)
         return query_string

--- a/stix_shifter/stix_translation/src/modules/dummy/stix_to_query.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/stix_to_query.py
@@ -7,9 +7,6 @@ from . import query_constructor
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
-
 
 class StixToQuery(BaseQueryTranslator):
 
@@ -28,11 +25,6 @@ class StixToQuery(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = data_mapping.DataMapper(options)
-
-        if 'result_limit' not in options:
-            options['result_limit'] = DEFAULT_LIMIT
-        if 'timerange' not in options:
-            options['timerange'] = DEFAULT_TIMERANGE
 
         query_string = query_constructor.translate_pattern(
             query_object, data_model_mapper, options)

--- a/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
@@ -9,8 +9,6 @@ import re
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
 REFERENCE_DATA_TYPES = {"sourceip": ["ipv4", "ipv6", "ipv4_cidr"],
                         "sourcemac": ["mac"],
                         "destinationip": ["ipv4", "ipv6", "ipv4_cidr"],
@@ -317,8 +315,8 @@ def _format_translated_queries(query_array):
 
 
 def translate_pattern(pattern: Pattern, data_model_mapping, options):
-    result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
-    timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE
+    result_limit = options['result_limit']
+    timerange = options['timerange']
     translated_where_statements = AqlQueryStringPatternTranslator(pattern, data_model_mapping, result_limit)
     select_statement = translated_where_statements.dmm.map_selections()
     queries = []

--- a/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
@@ -254,14 +254,10 @@ def _test_or_add_milliseconds(timestamp) -> str:
     # remove single quotes around timestamp
     timestamp = re.sub("'", "", timestamp)
     # check for 3-decimal milliseconds
-    pattern = "\.\d{3}Z$"
-    match = re.search(pattern, timestamp)
-    if bool(match):
-        return timestamp
-    else:
-        pattern = "(\.\d+Z$)|(Z$)"
-        timestamp = re.sub(pattern, ".000Z", timestamp)
-        return timestamp
+    pattern = "\.\d+Z$"
+    if not bool(re.search(pattern, timestamp)):
+        timestamp = re.sub('Z$', '.000Z', timestamp)
+    return timestamp
 
 
 def _test_START_STOP_format(query_string) -> bool:

--- a/stix_shifter/stix_translation/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/stix_to_aql.py
@@ -7,9 +7,6 @@ from . import aql_query_constructor
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
-
 
 class StixToAQL(BaseQueryTranslator):
 
@@ -28,10 +25,6 @@ class StixToAQL(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = qradar_data_mapping.QRadarDataMapper(options)
-        if 'result_limit' not in options:
-            options['result_limit'] = DEFAULT_LIMIT
-        if 'timerange' not in options:
-            options['timerange'] = DEFAULT_TIMERANGE
         query_string = aql_query_constructor.translate_pattern(
             query_object, data_model_mapper, options)
         return query_string

--- a/stix_shifter/stix_translation/src/modules/qradar/stix_to_aql.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/stix_to_aql.py
@@ -28,6 +28,10 @@ class StixToAQL(BaseQueryTranslator):
 
         query_object = generate_query(data)
         data_model_mapper = qradar_data_mapping.QRadarDataMapper(options)
+        if 'result_limit' not in options:
+            options['result_limit'] = DEFAULT_LIMIT
+        if 'timerange' not in options:
+            options['timerange'] = DEFAULT_TIMERANGE
         query_string = aql_query_constructor.translate_pattern(
             query_object, data_model_mapper, options)
         return query_string

--- a/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
@@ -8,8 +8,6 @@ from ..cim import cim_data_mapping
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LIMIT = 10000
-DEFAULT_TIMERANGE = 5
 DEFAULT_SEARCH_KEYWORD = "search"
 DEFAULT_FIELDS = "src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol"
 
@@ -49,8 +47,8 @@ class StixToSplunk(BaseQueryTranslator):
                 raise NotImplementedError(f"Module {data_mapper_module_name} does not implement mapper_class attribute")
 
         translate_options = {}
-        translate_options['result_limit'] = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
-        timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE
+        translate_options['result_limit'] = options['result_limit']
+        timerange = options['timerange']
         # append '-' as prefix and 'minutes' as suffix in timerange to convert minutes in SPL query format
         timerange = '-' + str(timerange) + 'minutes'
         translate_options['timerange'] = timerange

--- a/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/stix_to_splunk.py
@@ -13,6 +13,7 @@ DEFAULT_TIMERANGE = 5
 DEFAULT_SEARCH_KEYWORD = "search"
 DEFAULT_FIELDS = "src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol"
 
+
 class StixToSplunk(BaseQueryTranslator):
 
     def transform_query(self, data, options, mapping=None):
@@ -47,12 +48,13 @@ class StixToSplunk(BaseQueryTranslator):
             except AttributeError:
                 raise NotImplementedError(f"Module {data_mapper_module_name} does not implement mapper_class attribute")
 
-        result_limit = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
+        translate_options = {}
+        translate_options['result_limit'] = options['result_limit'] if 'result_limit' in options else DEFAULT_LIMIT
         timerange = options['timerange'] if 'timerange' in options else DEFAULT_TIMERANGE
-
         # append '-' as prefix and 'minutes' as suffix in timerange to convert minutes in SPL query format
         timerange = '-' + str(timerange) + 'minutes'
+        translate_options['timerange'] = timerange
 
         query_string = splunk_query_constructor.translate_pattern(
-            query_object, data_model_mapper, result_limit, DEFAULT_SEARCH_KEYWORD, timerange)
+            query_object, data_model_mapper, DEFAULT_SEARCH_KEYWORD, translate_options)
         return query_string

--- a/stix_shifter/stix_translation/src/transformers.py
+++ b/stix_shifter/stix_translation/src/transformers.py
@@ -158,8 +158,19 @@ class ToIPv4(ValueTransformer):
             print("Cannot convert input to IPv4 string")
 
 
+class DateTimeToUnixTimestamp(ValueTransformer):
+    """A value transformer for converting python datetime object to Unix (millisecond) timestamp"""
+
+    @staticmethod
+    def transform(obj):
+        try:
+            return int((obj - datetime(1970, 1, 1)).total_seconds() * 1000)
+        except ValueError:
+            print("Cannot convert input to Unix timestamp")
+
+
 def get_all_transformers():
     return {"SplunkToTimestamp": SplunkToTimestamp, "EpochToTimestamp": EpochToTimestamp, "ToInteger": ToInteger, "ToString": ToString,
             "ToLowercaseArray": ToLowercaseArray, "ToBase64": ToBase64, "ToFilePath": ToFilePath, "ToFileName": ToFileName,
             "StringToBool": StringToBool, "ToDomainName": ToDomainName, "TimestampToMilliseconds": TimestampToMilliseconds,
-            "EpochSecondsToTimestamp": EpochSecondsToTimestamp, "ToIPv4": ToIPv4 }
+            "EpochSecondsToTimestamp": EpochSecondsToTimestamp, "ToIPv4": ToIPv4, "DateTimeToUnixTimestamp": DateTimeToUnixTimestamp}

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -11,6 +11,8 @@ import sys
 TRANSLATION_MODULES = ['qradar', 'dummy', 'car', 'cim', 'splunk', 'elastic', 'bigfix', 'csa', 'csa:at', 'csa:nf', 'aws_security_hub', 'carbonblack']
 RESULTS = 'results'
 QUERY = 'query'
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
 
 
 class StixTranslation:
@@ -61,6 +63,10 @@ class StixTranslation:
                 if current_recursion_limit < recursion_limit:
                     print("Changing Python recursion limit from {} to {}".format(current_recursion_limit, recursion_limit))
                     sys.setrecursionlimit(recursion_limit)
+                if 'result_limit' not in options:
+                    options['result_limit'] = DEFAULT_LIMIT
+                if 'timerange' not in options:
+                    options['timerange'] = DEFAULT_TIMERANGE
                 errors = []
                 # Temporarily skip validation on patterns with START STOP qualifiers: validator doesn't yet support timestamp format
                 start_stop_pattern = "START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'\sSTOP"

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -80,7 +80,8 @@ class StixTranslation:
                     # Translating STIX pattern to antlr query object
                     query_object = generate_query(data)
                     # Converting query object to datasource query
-                    parsed_stix = parse_stix(query_object)
+                    parsed_stix_dictionary = parse_stix(query_object, options['timerange'])
+                    parsed_stix = parsed_stix_dictionary['parsed_stix']
                     # Todo: pass in the query_object instead of the data so we can remove multiple generate_query calls.
                     # Converting STIX pattern to datasource query
                     queries = interface.transform_query(data, options)

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -82,10 +82,12 @@ class StixTranslation:
                     # Converting query object to datasource query
                     parsed_stix_dictionary = parse_stix(query_object, options['timerange'])
                     parsed_stix = parsed_stix_dictionary['parsed_stix']
+                    start_time = parsed_stix_dictionary['start_time']
+                    end_time = parsed_stix_dictionary['end_time']
                     # Todo: pass in the query_object instead of the data so we can remove multiple generate_query calls.
                     # Converting STIX pattern to datasource query
                     queries = interface.transform_query(data, options)
-                    return {'queries': queries, 'parsed_stix': parsed_stix}
+                    return {'queries': queries, 'parsed_stix': parsed_stix, 'start_time': start_time, 'end_time': end_time}
             elif translate_type == RESULTS:
                 # Converting data from the datasource to STIX objects
                 try:

--- a/tests/bigfix_tests/test_stix_to_relevance.py
+++ b/tests/bigfix_tests/test_stix_to_relevance.py
@@ -4,8 +4,13 @@ import unittest
 translation = stix_translation.StixTranslation()
 
 
+def _test_query_assertions(query, queries, parsed_stix):
+    assert query['queries'] == queries
+    assert query['parsed_stix'] == parsed_stix
+
+
 class TestStixToRelevance(unittest.TestCase, object):
-        
+
     def test_process_query(self):
 
         stix_pattern = "[process:name = 'node' AND file:hashes.'SHA-256' = '0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5']"
@@ -15,9 +20,8 @@ class TestStixToRelevance(unittest.TestCase, object):
 
         queries = '<BESAPI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BESAPI.xsd"><ClientQuery><ApplicabilityRelevance>true</ApplicabilityRelevance><QueryText>( "process", name of it | "n/a", process id of it as string | "n/a", "sha256", sha256 of image file of it | "n/a", "sha1", sha1 of image file of it | "n/a", "md5", md5 of image file of it | "n/a", pathname of image file of it | "n/a", (start time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of processes whose (name of it as lowercase = "node" as lowercase AND sha256 of image file of it as lowercase = "0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5" as lowercase )</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
         parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': '0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5'}, {'attribute': 'process:name', 'comparison_operator': '=', 'value': 'node'}]
-        print(query)
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}    
-    
+        _test_query_assertions(query, queries, parsed_stix)
+
     def test_file_query(self):
 
         stix_pattern = "[file:name = 'a' AND file:parent_directory_ref.path = '/root' OR file:hashes.'SHA-256' = '2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d']"
@@ -26,6 +30,6 @@ class TestStixToRelevance(unittest.TestCase, object):
         # queries = '("file", name of it | "n/a", "sha256", sha256 of it | "n/a", "sha1", sha1 of it | "n/a", "md5", md5 of it | "n/a", pathname of it | "n/a", (modification time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of files whose (name of it as lowercase = "a" as lowercase OR sha256 of it as lowercase = "2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d" as lowercase) of folder ("/root")'
 
         queries = '<BESAPI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BESAPI.xsd"><ClientQuery><ApplicabilityRelevance>true</ApplicabilityRelevance><QueryText>("file", name of it | "n/a", "sha256", sha256 of it | "n/a", "sha1", sha1 of it | "n/a", "md5", md5 of it | "n/a", pathname of it | "n/a", (modification time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of files whose (name of it as lowercase = "a" as lowercase OR sha256 of it as lowercase = "2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d" as lowercase) of folder ("/root")</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
-        parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': '2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d'}, {'attribute': 'file:parent_directory_ref.path', 'comparison_operator': '=', 'value': '/root'}, {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'a'}]
-        print(query)
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': '2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d'},
+                       {'attribute': 'file:parent_directory_ref.path', 'comparison_operator': '=', 'value': '/root'}, {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'a'}]
+        _test_query_assertions(query, queries, parsed_stix)

--- a/tests/stix_translation/patterns/test_analytic_translator.py
+++ b/tests/stix_translation/patterns/test_analytic_translator.py
@@ -7,7 +7,11 @@ from os import listdir, path
 
 logging.basicConfig(level=logging.DEBUG)
 
-default_timerange_spl = '-' + str(stix_to_splunk.DEFAULT_TIMERANGE) + 'minutes'
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
+
+default_timerange_spl = '-' + str(DEFAULT_TIMERANGE) + 'minutes'
+
 
 class TestAnalyticTranslator(unittest.TestCase):
     """ Integration tests for the full pattern conversion process"""

--- a/tests/stix_translation/patterns/test_web_api.py
+++ b/tests/stix_translation/patterns/test_web_api.py
@@ -6,12 +6,14 @@ from web_api import *
 from .helpers.input_file_helpers import *
 from stix_shifter.stix_translation.src.modules.splunk import stix_to_splunk
 
-default_timerange_spl = '-' + str(stix_to_splunk.DEFAULT_TIMERANGE) + 'minutes'
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
+default_timerange_spl = '-' + str(DEFAULT_TIMERANGE) + 'minutes'
+
 
 class TestRunFlask(unittest.TestCase):
     """ Test the Flask server for Analytic Translator
         expects input files in test/input_files/ """
-
 
     @classmethod
     def setUpClass(cls):
@@ -20,44 +22,41 @@ class TestRunFlask(unittest.TestCase):
         app.testing = True
         return "Starting Flask server..."
 
-
     @classmethod
     def tearDownClass(cls):
         cls.server.terminate()
         cls.server.join()
         return "Flask Server shutting down..."
 
-
     @staticmethod
     def success_test_generator(pattern, platform, expected_result):
         """ Generates a successful test """
+
         def test(self):
             with app.test_client() as client:
                 resp = client.post(platform, data=pattern, content_type='text/plain')
                 data = resp.data
-                print("\n DATA: ", data.decode("utf-8"))  #### TEST-PRINT
+                print("\n DATA: ", data.decode("utf-8"))  # TEST-PRINT
                 self.assertEqual(TestRunFlask.normalize_spacing(data.decode("utf-8")),
-                    TestRunFlask.normalize_spacing(expected_result))
+                                 TestRunFlask.normalize_spacing(expected_result))
         return test
-
 
     @staticmethod
     def failure_test_generator(pattern, platform):
         """ Generates a test for an error """
+
         def test(self):
             with self.assertRaises(Exception):
                 with app.test_client() as client:
                     resp = client.post(platform, data=pattern, content_type='text/plain')
                     data = resp.data
-                    print("\n DATA: ", data.decode("utf-8"))  #### TEST-PRINT
+                    print("\n DATA: ", data.decode("utf-8"))  # TEST-PRINT
         return test
-
 
     def normalize_spacing(pattern):
         """ Normalizes spacing across expected results and actual results,
         so you don't need to put newlines/etc to match weird spacing exactly"""
         return re.sub(r"\s+", ' ', pattern)
-
 
     @staticmethod
     def input_files():
@@ -68,12 +67,11 @@ class TestRunFlask(unittest.TestCase):
         absolute_path_prefix = os.path.dirname(os.path.realpath(__file__))
         # do traversal of input_files
         for filename in listdir(path.join(absolute_path_prefix, "input_files")):
-            name, ext = path.splitext(filename) # reveal pattern name
+            name, ext = path.splitext(filename)  # reveal pattern name
             with open(path.join(absolute_path_prefix, "input_files", filename), "r") as json_data:
                 # add each file's pattern-dict to collected-dict
                 input_patterns[name] = json.load(json_data)
         return input_patterns
-
 
     @staticmethod
     def generate_tests():

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -5,6 +5,7 @@ import unittest
 import random
 import json
 import copy
+from freezegun import freeze_time
 
 options_file = open('tests/stix_translation/qradar_stix_to_aql/options.json').read()
 selections_file = open('stix_shifter/stix_translation/src/modules/qradar/json/aql_event_fields.json').read()
@@ -12,7 +13,11 @@ OPTIONS = json.loads(options_file)
 DEFAULT_SELECTIONS = json.loads(selections_file)
 DEFAULT_LIMIT = 10000
 DEFAULT_TIMERANGE = 5
+DEFAULT_START_TIME = 1548926700000
+DEFAULT_END_TIME = 1548927000000
 
+
+freeze_time("2019-01-31 09:30:00").start()
 selections = "SELECT {}".format(", ".join(DEFAULT_SELECTIONS['default']))
 custom_selections = "SELECT {}".format(", ".join(OPTIONS['select_fields']))
 from_statement = " FROM events "
@@ -41,68 +46,80 @@ default_time = "last {} minutes".format(DEFAULT_TIMERANGE)
 translation = stix_translation.StixTranslation()
 
 
+def _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix):
+    assert query['queries'] == [selections + from_statement + where_statement]
+    assert query['parsed_stix'] == parsed_stix
+    assert query['start_time'] == DEFAULT_START_TIME
+    assert query['end_time'] == DEFAULT_END_TIME
+
+
+def _translate_query(stix_pattern):
+    return translation.translate('qradar', 'query', '{}', stix_pattern)
+
+
 class TestStixToAql(unittest.TestCase, object):
+
     def test_ipv4_query(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '192.168.122.84/10']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE (INCIDR('192.168.122.84/10',sourceip) OR INCIDR('192.168.122.84/10',destinationip) OR INCIDR('192.168.122.84/10',identityip)) OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} {}".format(
             default_limit, default_time)
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84/10'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = '3001:0:0:0:0:0:0:2']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourceip = '3001:0:0:0:0:0:0:2' OR destinationip = '3001:0:0:0:0:0:0:2') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '3001:0:0:0:0:0:0:2'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE url = 'http://www.testaddress.com' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_query_from_multiple_observation_expressions_joined_by_AND(self):
         stix_pattern = "[url:value = 'www.example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
         where_statement = "WHERE (url = 'www.example.com') OR ((sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')) {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_query_from_multiple_comparison_expressions_joined_by_AND(self):
         stix_pattern = "[(url:value = 'www.example.com' OR url:value = 'www.test.com') AND mac-addr:value = '00-00-5E-00-53-00']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND (url = 'www.test.com' OR url = 'www.example.com') {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'},
                        {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.test.com'},
                        {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_file_query(self):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
         stix_pattern = "[file:name = 'some_file.exe']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE filename = 'some_file.exe' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE destinationport = '23456' OR sourceport = '12345' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
@@ -113,10 +130,10 @@ class TestStixToAql(unittest.TestCase, object):
 
     def test_user_account_query(self):
         stix_pattern = "[user-account:user_id = 'root']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE username = 'root' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
@@ -131,71 +148,82 @@ class TestStixToAql(unittest.TestCase, object):
             if random.randint(0, 1) == 0:
                 key = key.upper()
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
-            query = translation.translate('qradar', 'query', '{}', stix_pattern)
+            query = _translate_query(stix_pattern)
         where_statement = "WHERE protocolid = '{}' {} {}".format(value, default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' OR network-traffic:end = '2018-06-14T08:36:24.567Z']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE endtime = '1528965384567' OR starttime = '1528965384000' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.567Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_start_stop_qualifiers_with_one_observation(self):
         start_time_01 = "t'2016-06-01T01:30:00.123Z'"
         stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
-        epoch_start_time_01 = 1464744600123
-        epoch_stop_time_01 = 1464747600123
+        unix_start_time_01 = 1464744600123
+        unix_stop_time_01 = 1464747600123
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {}".format(start_time_01, stop_time_01)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, epoch_start_time_01, epoch_stop_time_01)
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}]
         assert len(query['queries']) == 1
-        assert query == {'queries': [selections + from_statement + where_statement_01], 'parsed_stix': parsed_stix}
+        assert query['queries'] == [selections + from_statement + where_statement]
+        assert query['parsed_stix'] == parsed_stix
+        assert query['start_time'] == unix_start_time_01
+        assert query['end_time'] == unix_stop_time_01
 
     def test_start_stop_qualifiers_with_two_observations(self):
         start_time_01 = "t'2016-06-01T01:30:00.123Z'"
         stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
         start_time_02 = "t'2016-06-01T03:55:00.123Z'"
         stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
-        epoch_start_time_01 = 1464744600123
-        epoch_stop_time_01 = 1464747600123
-        epoch_start_time_02 = 1464753300123
-        epoch_stop_time_02 = 1464755424743
+        unix_start_time_01 = 1464744600123
+        unix_stop_time_01 = 1464747600123
+        unix_start_time_02 = 1464753300123
+        unix_stop_time_02 = 1464755424743
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, epoch_start_time_01, epoch_stop_time_01)
-        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, epoch_start_time_02, epoch_stop_time_02)
+        query = _translate_query(stix_pattern)
+        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert len(query['queries']) == 2
-        assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
+        assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
+        assert query['parsed_stix'] == parsed_stix
+        # The biggest time window should be returned
+        assert query['start_time'] == unix_start_time_01
+        assert query['end_time'] == unix_stop_time_02
 
     def test_start_stop_qualifiers_with_three_observations(self):
         start_time_01 = "t'2016-06-01T00:00:00.123Z'"
         stop_time_01 = "t'2016-06-01T01:11:11.456Z'"
         start_time_02 = "t'2016-06-07T02:22:22.789Z'"
         stop_time_02 = "t'2016-06-07T03:33:33.012Z'"
-        epoch_start_time_01 = 1464739200123
-        epoch_stop_time_01 = 1464743471456
-        epoch_start_time_02 = 1465266142789
-        epoch_stop_time_02 = 1465270413012
+        unix_start_time_01 = 1464739200123
+        unix_stop_time_01 = 1464743471456
+        unix_start_time_02 = 1465266142789
+        unix_stop_time_02 = 1465270413012
         stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START {} STOP {} OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0'] START {} STOP {}".format(
             start_time_01, stop_time_01, start_time_02, stop_time_02)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, epoch_start_time_01, epoch_stop_time_01)
-        where_statement_02 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') {} START {} STOP {}".format(default_limit, epoch_start_time_02, epoch_stop_time_02)
+        query = _translate_query(stix_pattern)
+        where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+        where_statement_02 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
         where_statement_03 = "WHERE url = 'www.example.com' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'}]
         assert len(query['queries']) == 3
-        assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02, selections + from_statement + where_statement_03], 'parsed_stix': parsed_stix}
+        assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02, selections + from_statement + where_statement_03]
+        assert query['parsed_stix'] == parsed_stix
+        # The biggest time window should be returned
+        assert query['start_time'] == unix_start_time_01
+        assert query['end_time'] == unix_stop_time_02
 
     def test_start_stop_qualifiers_with_missing_or_partial_milliseconds(self):
         # missing milliseconds
@@ -205,25 +233,29 @@ class TestStixToAql(unittest.TestCase, object):
         start_time_02 = "t'2016-06-01T03:55:00.1Z'"
         # four-digit millisecond
         stop_time_02 = "t'2016-06-01T04:30:24.1243Z'"
-        epoch_start_time_01 = 1464744600000
-        epoch_stop_time_01 = 1464747600000
-        epoch_start_time_02 = 1464753300000
-        epoch_stop_time_02 = 1464755424000
+        unix_start_time_01 = 1464744600000
+        unix_stop_time_01 = 1464747600000
+        unix_start_time_02 = 1464753300100
+        unix_stop_time_02 = 1464755424124
         stix_pattern = "[user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
-        where_statement_01 = "WHERE username = 'root' {} START {} STOP {}".format(default_limit, epoch_start_time_01, epoch_stop_time_01)
-        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, epoch_start_time_02, epoch_stop_time_02)
+        query = _translate_query(stix_pattern)
+        where_statement_01 = "WHERE username = 'root' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
                        {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert len(query['queries']) == 2
-        assert query == {'queries': [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02], 'parsed_stix': parsed_stix}
+        assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
+        assert query['parsed_stix'] == parsed_stix
+        # The biggest time window should be returned
+        assert query['start_time'] == unix_start_time_01
+        assert query['end_time'] == unix_stop_time_02
 
     def test_set_operators(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip)) {} {}".format(default_limit, default_time)
         parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'ISSUBSET', 'attribute': 'ipv4-addr:value'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     # def test_custom_time_limit_and_result_count_and_mappings(self):
     #     stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
@@ -235,17 +267,17 @@ class TestStixToAql(unittest.TestCase, object):
 
     def test_domainname_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE domainname LIKE '%example.com%' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_generic_filehash_query(self):
         stix_pattern = "[file:hashes.'SHA-256' = 'sha256hash']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE filehash = 'sha256hash' {} {}".format(default_limit, default_time)
         parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': 'sha256hash'}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     # def test_sha256_filehash_query(self):
     #     stix_pattern = "[file:hashes.'SHA-256' = 'sha256hash']"
@@ -279,14 +311,14 @@ class TestStixToAql(unittest.TestCase, object):
         for ref_index, reference in enumerate(["network-traffic:src_ref.value", "network-traffic:dst_ref.value"]):
             for dat_index, datum in enumerate(["'192.0.2.0'", "'00-00-5E-00-53-00'", "'192.0.2.0/25'", "'3001:0:0:0:0:0:0:2'"]):
                 stix_pattern = "[{} = {}]".format(reference, datum)
-                query = translation.translate('qradar', 'query', '{}', stix_pattern)
+                query = _translate_query(stix_pattern)
                 where_statement = where_statements[ref_index][dat_index]
                 parsed_stix = [{'attribute': reference, 'comparison_operator': '=', 'value': datum.strip("'")}]
-                assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+                _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_nested_parenthesis_in_pattern(self):
         stix_pattern = "[(ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '100.100.122.90') AND network-traffic:src_port = 37020] OR [user-account:user_id = 'root'] AND [url:value = 'www.example.com']"
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourceport = '37020' AND ((sourceip = '100.100.122.90' OR destinationip = '100.100.122.90' OR identityip = '100.100.122.90') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83'))) OR ((username = 'root') OR (url = 'www.example.com')) {} {}".format(default_limit, default_time)
         parsed_stix = [
             {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
@@ -302,26 +334,26 @@ class TestStixToAql(unittest.TestCase, object):
     def test_LIKE_operator(self):
         search_string = 'example.com'
         stix_pattern = "[url:value LIKE '{}']".format(search_string)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE url LIKE '%{}%' {} {}".format(search_string, default_limit, default_time)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': 'LIKE', 'value': search_string}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_payload_string_matching_with_LIKE(self):
         search_string = 'search term'
         stix_pattern = "[x-readable-payload:value LIKE '{}']".format(search_string)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE TEXT SEARCH '{}' {} {}".format(search_string, default_limit, default_time)
         parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'LIKE', 'value': search_string}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_payload_string_matching_with_MATCH(self):
         search_string = '^.*https://wally.fireeye.com.*$'
         stix_pattern = "[x-readable-payload:value MATCHES '{}']".format(search_string)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         where_statement = "WHERE utf8_payload MATCHES '{}' {} {}".format(search_string, default_limit, default_time)
         parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'MATCHES', 'value': search_string}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
     def test_backslash_escaping(self):
         # Stix pattern requires backslash to be double escaped to pass pattern validation.
@@ -329,8 +361,8 @@ class TestStixToAql(unittest.TestCase, object):
         # See https://github.com/oasis-open/cti-stix2-json-schemas/issues/51
         search_string = '^.*http://graphics8\\\.nytimes\\\.com/bcvideo.*$'
         stix_pattern = "[x-readable-payload:value MATCHES '{}']".format(search_string)
-        query = translation.translate('qradar', 'query', '{}', stix_pattern)
+        query = _translate_query(stix_pattern)
         translated_value = '^.*http://graphics8\\.nytimes\\.com/bcvideo.*$'
         where_statement = "WHERE utf8_payload MATCHES '{}' {} {}".format(translated_value, default_limit, default_time)
         parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'MATCHES', 'value': translated_value}]
-        assert query == {'queries': [selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -31,6 +31,11 @@ default_timerange_spl = '-' + str(DEFAULT_TIMERANGE) + 'minutes'
 translation = stix_translation.StixTranslation()
 
 
+def _test_query_assertions(query, queries, parsed_stix):
+    assert query['queries'] == queries
+    assert query['parsed_stix'] == parsed_stix
+
+
 class TestStixToSpl(unittest.TestCase, object):
 
     def test_ipv4_query(self):
@@ -38,35 +43,35 @@ class TestStixToSpl(unittest.TestCase, object):
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (((src_ip = "192.168.122.84") OR (dest_ip = "192.168.122.84")) OR ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = 'fe80::8c3b:a720:dc5c:2abf%19']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_ipv6 = "fe80::8c3b:a720:dc5c:2abf%19") OR (dest_ipv6 = "fe80::8c3b:a720:dc5c:2abf%19")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': 'fe80::8c3b:a720:dc5c:2abf%19'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
         queries = 'search (url = "http://www.testaddress.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_domain_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (url = "example.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_query_from_multiple_observation_expressions_joined_by_AND(self):
         stix_pattern = "[domain-name:value = 'example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
@@ -74,7 +79,7 @@ class TestStixToSpl(unittest.TestCase, object):
         # Expect the STIX AND to convert to an SPL OR.
         queries = 'search (url = "example.com") OR ((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_query_from_multiple_comparison_expressions_joined_by_AND(self):
         stix_pattern = "[domain-name:value = 'example.com' AND mac-addr:value = '00-00-5E-00-53-00']"
@@ -82,21 +87,21 @@ class TestStixToSpl(unittest.TestCase, object):
         # Expect the STIX AND to convert to an AQL AND.
         queries = 'search (((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) AND (url = "example.com")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_file_query(self):
         stix_pattern = "[file:name = 'some_file.exe']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (file_name = "some_file.exe") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((dest_port = 23456) OR (src_port = 12345)) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
@@ -121,35 +126,35 @@ class TestStixToSpl(unittest.TestCase, object):
             query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (protocol = "'+key+'") earliest="{}" | head {} | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'.format(default_timerange_spl, DEFAULT_LIMIT)
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' OR network-traffic:end = '2018-06-14T08:36:24.000Z']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((latest = "2018-06-14T08:36:24.000Z") OR (earliest = "2018-06-14T08:36:24.000Z")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_start_stop_qualifiers(self):
         stix_pattern = "[network-traffic:src_port = 37020] START t'2016-06-01T01:30:00.000Z' STOP t'2016-06-01T02:20:00.000Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00.000Z' STOP t'2016-06-01T04:30:00.000Z'"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (src_port = 37020) earliest="06/01/2016:01:30:00" latest="06/01/2016:02:20:00" OR ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83")) earliest="06/01/2016:03:55:00" latest="06/01/2016:04:30:00" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_start_stop_qualifiers_one_time(self):
         stix_pattern = "[network-traffic:src_port = 37020] START t'2016-06-01T01:30:00.000Z' STOP t'2016-06-01T02:20:00.000Z'"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (src_port = 37020) earliest="06/01/2016:01:30:00" latest="06/01/2016:02:20:00" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_issubset_operator(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_ip = "198.51.100.0/24") OR (dest_ip = "198.51.100.0/24")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': 'ISSUBSET', 'value': '198.51.100.0/24'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_custom_time_limit_and_result_count(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
@@ -161,7 +166,7 @@ class TestStixToSpl(unittest.TestCase, object):
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83")) earliest="-25minutes" | head 5000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_custom_mapping(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' AND mac-addr:value = '00-00-5E-00-53-00']"
@@ -198,7 +203,7 @@ class TestStixToSpl(unittest.TestCase, object):
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search ((mac = "00-00-5E-00-53-00") AND ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-15minutes" | head 1000 | fields src_ip, src_port'
         parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)
 
     def test_free_search(self):
         stix_pattern = "[x-readable-payload:value = 'malware']"
@@ -210,4 +215,4 @@ class TestStixToSpl(unittest.TestCase, object):
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search _raw=*malware* earliest="-25minutes" | head 5000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': '=', 'value': 'malware'}]
-        assert query == {'queries': queries, 'parsed_stix': parsed_stix}
+        _test_query_assertions(query, queries, parsed_stix)

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -6,6 +6,9 @@ from stix_shifter.utils.error_response import ErrorCode
 import unittest
 import random
 
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
+
 protocols = {
     "tcp": "6",
     "udp": "17",
@@ -23,7 +26,7 @@ protocols = {
     "sctp": "132"
 }
 
-default_timerange_spl = '-' + str(stix_to_splunk.DEFAULT_TIMERANGE) + 'minutes'
+default_timerange_spl = '-' + str(DEFAULT_TIMERANGE) + 'minutes'
 
 translation = stix_translation.StixTranslation()
 
@@ -101,7 +104,7 @@ class TestStixToSpl(unittest.TestCase, object):
         assert False == result['success']
         assert ErrorCode.TRANSLATION_MAPPING_ERROR.value == result['code']
         assert result['error'].startswith('data mapping error : Unable to map property')
-        
+
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
         result = translation.translate('splunk', 'query', '{}', stix_pattern)
@@ -116,7 +119,7 @@ class TestStixToSpl(unittest.TestCase, object):
                 key = key.upper()
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
             query = translation.translate('splunk', 'query', '{}', stix_pattern)
-        queries = 'search (protocol = "'+key+'") earliest="{}" | head {} | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'.format(default_timerange_spl, stix_to_splunk.DEFAULT_LIMIT)
+        queries = 'search (protocol = "'+key+'") earliest="{}" | head {} | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'.format(default_timerange_spl, DEFAULT_LIMIT)
         parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
         assert query == {'queries': queries, 'parsed_stix': parsed_stix}
 


### PR DESCRIPTION
Return start and end times as part of the pattern translation. The return format is now:
```
{
   "queries": [<translated datasource queries>],
   "parsed_stix": [<stix parsings with attribute, operator, value>],
   "start_time": <unix timestamp of earliest START time or default time range of -5 minutes from current UTC time (or an optional override of last X-minutes>,
   "end_time": <unix timestamp of latest STOP time or the current UTC time>
}
```

If a START STOP qualifier is in the pattern, that takes precedence over the default time range. 