### PR TITLE
Support for unmapped STIX attributes in AQL translation

### DIFF
--- a/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
@@ -191,8 +191,8 @@ class AqlQueryStringPatternTranslator:
         operator = self.comparator_lookup[expression.operator]
         expression_01 = self._parse_expression(expression.expr1)
         expression_02 = self._parse_expression(expression.expr2)
-        expression_01_nomap = re.search("^NOMAP", expression_01)
-        expression_02_nomap = re.search("^NOMAP", expression_02)
+        expression_01_nomap = expression_01.startswith("NOMAP")
+        expression_02_nomap = expression_02.startswith("NOMAP")
         if operator == 'AND':
             if expression_01_nomap or expression_02_nomap:
                 self.observation_count -= 1

--- a/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/aql_query_constructor.py
@@ -147,107 +147,140 @@ class AqlQueryStringPatternTranslator:
     def _is_reference_value(stix_field):
         return stix_field == 'src_ref.value' or stix_field == 'dst_ref.value'
 
+    @staticmethod
+    def _format_value(self, expression):
+        if expression.comparator == ComparisonComparators.Matches:
+            # needs forward slashes
+            return self._format_match(expression.value)
+        # should be (x, y, z, ...)
+        elif expression.comparator == ComparisonComparators.In:
+            return self._format_set(expression.value)
+        elif expression.comparator == ComparisonComparators.Equal or expression.comparator == ComparisonComparators.NotEqual:
+            # Should be in single-quotes
+            return self._format_equality(expression.value)
+        # '%' -> '*' wildcard, '_' -> '?' single wildcard
+        elif expression.comparator == ComparisonComparators.Like and not (expression.object_path == 'x-readable-payload:value'):
+            return self._format_like(expression.value)
+        else:
+            return self._escape_value(expression.value)
+
+    @staticmethod
+    def _parse_combined_observation_expression(self, expression):
+        # The pattern has at least one other ObservationExpression
+        self.observation_count += 1
+        operator = self.comparator_lookup[expression.operator]
+        expression_01 = self._parse_expression(expression.expr1)
+        expression_02 = self._parse_expression(expression.expr2)
+        expression_01_nomap = re.search("^NOMAP", expression_01)
+        expression_02_nomap = re.search("^NOMAP", expression_02)
+        # Both expressions are unmapped so throw an error
+        if expression_01_nomap and expression_02_nomap:
+            error_id = expression_01.split(":")[1]
+            raise self.dmm.mapping_errors[error_id]
+        elif expression_01 and (not expression_02 or expression_02_nomap):
+            return "{}".format(expression_01)
+        elif expression_02 and (not expression_01 or expression_01_nomap):
+            return "{}".format(expression_02)
+        elif expression_01 and expression_02:
+            return "({}) {} ({})".format(expression_01, operator, expression_02)
+        else:
+            return ''
+
+    @staticmethod
+    def _parse_combined_comparison_expression(self, expression, qualifier=None):
+        operator = self.comparator_lookup[expression.operator]
+        expression_01 = self._parse_expression(expression.expr1)
+        expression_02 = self._parse_expression(expression.expr2)
+        expression_01_nomap = re.search("^NOMAP", expression_01)
+        expression_02_nomap = re.search("^NOMAP", expression_02)
+        if operator == 'AND':
+            if expression_01_nomap or expression_02_nomap:
+                self.observation_count -= 1
+                # There are more observation expressions to check so skip this one and continue
+                if self.observation_count > 0:
+                    return ''
+            # Only one observation expression and it has unmapped attribute with the AND operator
+            if expression_01_nomap:
+                error_id = expression_01.split(":")[1]
+                raise self.dmm.mapping_errors[error_id]
+            if expression_02_nomap:
+                error_id = expression_02.split(":")[1]
+                raise self.dmm.mapping_errors[error_id]
+        if isinstance(expression.expr1, CombinedComparisonExpression):
+            expression_01 = "({})".format(expression_01)
+        if isinstance(expression.expr2, CombinedComparisonExpression):
+            expression_02 = "({})".format(expression_02)
+        if expression_01_nomap and expression_02_nomap:
+            return ''
+        elif expression_01_nomap:
+            query_string = "{}".format(expression_02)
+        elif expression_02_nomap:
+            query_string = "{}".format(expression_01)
+        else:
+            query_string = "{} {} {}".format(expression_01, operator, expression_02)
+        if qualifier is not None:
+            self.qualified_queries.append("{} limit {} {}".format(query_string, self.result_limit, qualifier))
+            return ''
+        else:
+            return "{}".format(query_string)
+
+    @staticmethod
+    def _parse_comparison_expression(self, expression, qualifier=None, calling_object_type=None):
+        # Resolve STIX Object Path to a field in the target Data Model
+        stix_object, stix_field = expression.object_path.split(':')
+        # Multiple QRadar fields may map to the same STIX Object
+        mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
+        # Resolve the comparison symbol to use in the query string (usually just ':')
+        comparator = self.comparator_lookup[expression.comparator]
+
+        if stix_field == 'protocols[*]':
+            map_data = _fetch_network_protocol_mapping()
+            try:
+                expression.value = map_data[expression.value.lower()]
+            except Exception as protocol_key:
+                raise KeyError(
+                    "Network protocol {} is not supported.".format(protocol_key))
+        elif stix_field == 'start' or stix_field == 'end':
+            transformer = TimestampToMilliseconds()
+            expression.value = transformer.transform(expression.value)
+
+        # Some values are formatted differently based on how they're being compared
+        value = self._format_value(self, expression)
+
+        comparison_string = self._parse_mapped_fields(self, expression, value, comparator, stix_field, mapped_fields_array)
+
+        pattern = "NOMAP:[a-zA-Z0-9]{8}-([a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12}"
+        nomap_search = re.search(pattern, comparison_string)
+        if nomap_search:
+            nomap_with_uuid = nomap_search.group(0)
+            if calling_object_type == 'ObservationExpression' and self.observation_count == 1:
+                # Pattern has only one ObservationExpression with one unmapped ComparisonExpression
+                error_id = nomap_with_uuid.split(":")[1]
+                raise self.dmm.mapping_errors[error_id]
+            else:
+                return nomap_with_uuid
+
+        if(len(mapped_fields_array) > 1 and not self._is_reference_value(stix_field)):
+            # More than one AQL field maps to the STIX attribute so group the ORs.
+            grouped_comparison_string = "(" + comparison_string + ")"
+            comparison_string = grouped_comparison_string
+
+        if expression.comparator == ComparisonComparators.NotEqual:
+            comparison_string = self._negate_comparison(comparison_string)
+
+        if expression.negated:
+            comparison_string = self._negate_comparison(comparison_string)
+        if qualifier is not None:
+            self.qualified_queries.append("{} limit {} {}".format(comparison_string, self.result_limit, qualifier))
+            return ''
+        else:
+            return "{}".format(comparison_string)
+
     def _parse_expression(self, expression, qualifier=None, calling_object_type=None) -> str:
         if isinstance(expression, ComparisonExpression):  # Base Case
-            # Resolve STIX Object Path to a field in the target Data Model
-            stix_object, stix_field = expression.object_path.split(':')
-            # Multiple QRadar fields may map to the same STIX Object
-            mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
-            # Resolve the comparison symbol to use in the query string (usually just ':')
-            comparator = self.comparator_lookup[expression.comparator]
-
-            if stix_field == 'protocols[*]':
-                map_data = _fetch_network_protocol_mapping()
-                try:
-                    expression.value = map_data[expression.value.lower()]
-                except Exception as protocol_key:
-                    raise KeyError(
-                        "Network protocol {} is not supported.".format(protocol_key))
-            elif stix_field == 'start' or stix_field == 'end':
-                transformer = TimestampToMilliseconds()
-                expression.value = transformer.transform(expression.value)
-
-            # Some values are formatted differently based on how they're being compared
-            if expression.comparator == ComparisonComparators.Matches:  # needs forward slashes
-                value = self._format_match(expression.value)
-            # should be (x, y, z, ...)
-            elif expression.comparator == ComparisonComparators.In:
-                value = self._format_set(expression.value)
-            elif expression.comparator == ComparisonComparators.Equal or expression.comparator == ComparisonComparators.NotEqual:
-                # Should be in single-quotes
-                value = self._format_equality(expression.value)
-            # '%' -> '*' wildcard, '_' -> '?' single wildcard
-            elif expression.comparator == ComparisonComparators.Like and not (expression.object_path == 'x-readable-payload:value'):
-                value = self._format_like(expression.value)
-            else:
-                value = self._escape_value(expression.value)
-
-            comparison_string = self._parse_mapped_fields(self, expression, value, comparator, stix_field, mapped_fields_array)
-
-            pattern = "NOMAP:[a-zA-Z0-9]{8}-([a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12}"
-            nomap_search = re.search(pattern, comparison_string)
-            if nomap_search:
-                nomap_with_uuid = nomap_search.group(0)
-                if calling_object_type == 'ObservationExpression' and self.observation_count == 1:
-                    # Pattern has only one ObservationExpression with one unmapped ComparisonExpression
-                    error_id = nomap_with_uuid.split(":")[1]
-                    raise self.dmm.mapping_errors[error_id]
-                else:
-                    return nomap_with_uuid
-
-            if(len(mapped_fields_array) > 1 and not self._is_reference_value(stix_field)):
-                # More than one AQL field maps to the STIX attribute so group the ORs.
-                grouped_comparison_string = "(" + comparison_string + ")"
-                comparison_string = grouped_comparison_string
-
-            if expression.comparator == ComparisonComparators.NotEqual:
-                comparison_string = self._negate_comparison(comparison_string)
-
-            if expression.negated:
-                comparison_string = self._negate_comparison(comparison_string)
-            if qualifier is not None:
-                self.qualified_queries.append("{} limit {} {}".format(comparison_string, self.result_limit, qualifier))
-                return ''
-            else:
-                return "{}".format(comparison_string)
-
+            return self._parse_comparison_expression(self, expression, qualifier, calling_object_type)
         elif isinstance(expression, CombinedComparisonExpression):
-            operator = self.comparator_lookup[expression.operator]
-            expression_01 = self._parse_expression(expression.expr1)
-            expression_02 = self._parse_expression(expression.expr2)
-            # WILL ERROR IN ALL CASES WHERE THERE'S AN AND
-            expression_01_nomap = re.search("^NOMAP", expression_01)
-            expression_02_nomap = re.search("^NOMAP", expression_02)
-            if operator == 'AND':
-                if expression_01_nomap or expression_02_nomap:
-                    self.observation_count -= 1
-                    # There are more observation expressions to check so skip this one and continue
-                    if self.observation_count > 0:
-                        return ''
-                # Currently in the only observation expression with an unmapped attribute and the AND operator
-                if expression_01_nomap:
-                    error_id = expression_01.split(":")[1]
-                    raise self.dmm.mapping_errors[error_id]
-                if expression_02_nomap:
-                    error_id = expression_02.split(":")[1]
-                    raise self.dmm.mapping_errors[error_id]
-            if isinstance(expression.expr1, CombinedComparisonExpression):
-                expression_01 = "({})".format(expression_01)
-            if isinstance(expression.expr2, CombinedComparisonExpression):
-                expression_02 = "({})".format(expression_02)
-            if expression_01_nomap and expression_02_nomap:
-                return ''
-            elif expression_01_nomap:
-                query_string = "{}".format(expression_02)
-            elif expression_02_nomap:
-                query_string = "{}".format(expression_01)
-            else:
-                query_string = "{} {} {}".format(expression_01, operator, expression_02)
-            if qualifier is not None:
-                self.qualified_queries.append("{} limit {} {}".format(query_string, self.result_limit, qualifier))
-                return ''
-            else:
-                return "{}".format(query_string)
+            return self._parse_combined_comparison_expression(self, expression, qualifier)
         elif isinstance(expression, ObservationExpression):
             return "{}".format(self._parse_expression(expression.comparison_expression, qualifier, 'ObservationExpression'))
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
@@ -260,24 +293,7 @@ class AqlQueryStringPatternTranslator:
             else:
                 return self._parse_expression(expression.observation_expression.comparison_expression, expression.qualifier)
         elif isinstance(expression, CombinedObservationExpression):
-            self.observation_count += 1
-            operator = self.comparator_lookup[expression.operator]
-            expression_01 = self._parse_expression(expression.expr1)
-            expression_02 = self._parse_expression(expression.expr2)
-            expression_01_nomap = re.search("^NOMAP", expression_01)
-            expression_02_nomap = re.search("^NOMAP", expression_02)
-            # Both expressions are unmapped so thrown an error
-            if expression_01_nomap and expression_02_nomap:
-                error_id = expression_01.split(":")[1]
-                raise self.dmm.mapping_errors[error_id]
-            elif expression_01 and (not expression_02 or expression_02_nomap):
-                return "{}".format(expression_01)
-            elif expression_02 and (not expression_01 or expression_01_nomap):
-                return "{}".format(expression_02)
-            elif expression_01 and expression_02:
-                return "({}) {} ({})".format(expression_01, operator, expression_02)
-            else:
-                return ''
+            return self._parse_combined_observation_expression(self, expression)
         elif isinstance(expression, Pattern):
             return "{expr}".format(expr=self._parse_expression(expression.expression))
         else:

--- a/stix_shifter/stix_translation/src/modules/qradar/qradar_data_mapping.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/qradar_data_mapping.py
@@ -1,6 +1,7 @@
 from os import path
 import json
 from stix_shifter.stix_translation.src.exceptions import DataMappingException
+import uuid
 
 
 def _fetch_mapping():
@@ -23,13 +24,16 @@ class QRadarDataMapper:
         self.mapping_json = options['mapping'] if 'mapping' in options else {}
         self.select_fields_json = options['select_fields'] if 'select_fields' in options else {}
         self.map_data = self.mapping_json or _fetch_mapping()
+        self.mapping_errors = {}
 
     def map_field(self, stix_object_name, stix_property_name):
         if stix_object_name in self.map_data and stix_property_name in self.map_data[stix_object_name]["fields"]:
             return self.map_data[stix_object_name]["fields"][stix_property_name]
         else:
-            raise DataMappingException("Unable to map property `{}:{}` into AQL".format(
-                stix_object_name, stix_property_name))
+            # Preemptively create the mapping error with a UUID so it can be referenced in the query constructor.
+            error_id = str(uuid.uuid4())
+            self.mapping_errors[error_id] = DataMappingException("Unable to map property `{}:{}` into AQL".format(stix_object_name, stix_property_name))
+            return ["NOMAP:{}".format(error_id)]
 
     def map_selections(self):
         try:

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -121,12 +121,50 @@ class TestStixToAql(unittest.TestCase, object):
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
         _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
 
-    def test_unmapped_attribute(self):
+    def test_unmapped_attribute_with_AND(self):
+        stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever' AND file:name = 'some_file.exe']"
+        result = translation.translate('qradar', 'query', '{}', stix_pattern)
+        assert result['success'] == False
+        assert ErrorCode.TRANSLATION_MAPPING_ERROR.value == result['code']
+        assert 'Unable to map property' in result['error']
+
+    def test_pattern_with_one_observation_exp_with_one_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
         result = translation.translate('qradar', 'query', '{}', stix_pattern)
         assert result['success'] == False
         assert ErrorCode.TRANSLATION_MAPPING_ERROR.value == result['code']
         assert 'Unable to map property' in result['error']
+
+    def test_unmapped_attribute_with_OR(self):
+        stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever' OR file:name = 'some_file.exe']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE filename = 'some_file.exe' {} {}".format(default_limit, default_time)
+        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'},
+                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
+        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+
+    def test_pattern_with_two_observation_exps_one_with_unmapped_attribute(self):
+        stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever'] OR [file:name = 'some_file.exe' AND url:value = 'www.example.com']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE url = 'www.example.com' AND filename = 'some_file.exe' {} {}".format(default_limit, default_time)
+        parsed_stix = [{'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'},
+                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
+                       {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
+        for parsing in parsed_stix:
+            assert parsing in query['parsed_stix']
+        assert query['queries'] == [selections + from_statement + where_statement]
+
+    def test_pattern_with_three_observation_exps_one_with_unmapped_attribute(self):
+        stix_pattern = "[file:name = 'some_file.exe' AND network-traffic:some_invalid_attribute = 'whatever'] OR [url:value = 'www.example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE (url = 'www.example.com') OR ((sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')) {} {}".format(default_limit, default_time)
+        parsed_stix = [{'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'},
+                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
+                       {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'},
+                       {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
+        for parsing in parsed_stix:
+            assert parsing in query['parsed_stix']
+        assert query['queries'] == [selections + from_statement + where_statement]
 
     def test_user_account_query(self):
         stix_pattern = "[user-account:user_id = 'root']"
@@ -165,14 +203,16 @@ class TestStixToAql(unittest.TestCase, object):
         stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
         unix_start_time_01 = 1464744600123
         unix_stop_time_01 = 1464747600123
-        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {}".format(start_time_01, stop_time_01)
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root' OR network-traffic:some_invalid_attribute = 'whatever'] START {} STOP {}".format(start_time_01, stop_time_01)
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+        where_statement = "WHERE (username = 'root' AND sourceport = '37020') {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
         parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}]
+                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
+                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
         assert len(query['queries']) == 1
         assert query['queries'] == [selections + from_statement + where_statement]
-        assert query['parsed_stix'] == parsed_stix
+        for parsing in parsed_stix:
+            assert parsing in query['parsed_stix']
         assert query['start_time'] == unix_start_time_01
         assert query['end_time'] == unix_stop_time_01
 
@@ -208,7 +248,7 @@ class TestStixToAql(unittest.TestCase, object):
         unix_stop_time_01 = 1464743471456
         unix_start_time_02 = 1465266142789
         unix_stop_time_02 = 1465270413012
-        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START {} STOP {} OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0'] START {} STOP {}".format(
+        stix_pattern = "[network-traffic:src_port = 37020 AND network-traffic:dst_port = 635] START {} STOP {} OR [url:value = 'www.example.com'] OR [ipv4-addr:value = '333.333.333.0' OR network-traffic:some_invalid_attribute = 'whatever'] START {} STOP {}".format(
             start_time_01, stop_time_01, start_time_02, stop_time_02)
         query = _translate_query(stix_pattern)
         where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
@@ -217,10 +257,12 @@ class TestStixToAql(unittest.TestCase, object):
         parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
                        {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
                        {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'}]
+                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'},
+                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
         assert len(query['queries']) == 3
         assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02, selections + from_statement + where_statement_03]
-        assert query['parsed_stix'] == parsed_stix
+        for parsing in parsed_stix:
+            assert parsing in query['parsed_stix']
         # The biggest time window should be returned
         assert query['start_time'] == unix_start_time_01
         assert query['end_time'] == unix_stop_time_02


### PR DESCRIPTION
*** The below is required to be filled by any non-IBM employee, in order for their pull request to be accepted ***
DCO 1.1 Signed-off-by: [NAME] <[EMAIL]>

Before, when a submitted pattern contained an unmapped STIX attribute, an error was immediately thrown when translating from STIX to AQL queries. Now in certain cases, the unmapped comparison expression is removed, and an AQL query is constructed from the mapped elements. Previously, a query string was built from the ANTLR parsing as it was recursively run through the `_parse_expression()` method in `aql_query_constructor.py`. Now `_parse_expression()` inserts the ANTLR elements (queries, operators, START STOP qualifiers) into an object structure where groupings can be preserved; this is then used to build the final query strings using the `_parse_translated_query_objects()` method

**Pattern examples that will still throw the error:**

Pattern contains only one observation and it contains only one comparison expression and it is unmapped:
`[unmapped:attribute = someValue]`

Pattern contains only one observation and it contains multiple comparison expressions, one of which is unmapped but it is joined to another comparison with an AND operator:
`[unmapped:attribute = someValue AND mapped:attribute = someValue OR mapped:attribute = someValue]`

_**NOTE**: Work could still be done to handle comparisons that are grouped by parenthesis rather than throwing out the entire observation_

**Pattern examples that will produce an AQL query that omits the unmapped comparison:**

`[unmapped:attribute = someValue] OR [mapped:attribute = someValue]`
`[unmapped:attribute = someValue OR mapped:attribute = someValue]`


