### PR TITLE
STIX pattern parsing

### DIFF
--- a/adapter-guide/develop-stix-adapter.md
+++ b/adapter-guide/develop-stix-adapter.md
@@ -1,115 +1,118 @@
 # Developing a new STIX-shifter adapter
 
-* [Introduction](../README.md)
-* [Scenario](#scenario)
-* [Prerequisites](#prerequisites)
-* [Steps](#steps)
+- [Introduction](../README.md)
+- [Scenario](#scenario)
+- [Prerequisites](#prerequisites)
+- [Steps](#steps)
 
 ## Scenario
 
 ### Participants
-This scenario involves a software developer (*Developer A*) and an end user (*User A*). *Developer A* wants to implement a new adapter for the STIX-shifter project that can support a particular security product (*Product A*). *User A* is another developer that uses the STIX-shifter library.
+
+This scenario involves a software developer (_Developer A_) and an end user (_User A_). _Developer A_ wants to implement a new adapter for the STIX-shifter project that can support a particular security product (_Product A_). _User A_ is another developer that uses the STIX-shifter library.
 
 ### Problem to solve
-*User A* performs security monitoring with *Product A* and several other security products. The other products already have existing STIX-shifter adapters. 
 
-*User A* would like to:
-1.	Submit one STIX pattern to query all the user’s security products at once. The use of a STIX pattern simplifies the search process because *User A* does not need to know the query language or API calls for each security product. 
-1.	See the query results from all the security products in one unified format (STIX bundle). With the assumption that the submitted pattern represents a potential security incident, the STIX bundle presents the query results in the context of the security event. 
+_User A_ performs security monitoring with _Product A_ and several other security products. The other products already have existing STIX-shifter adapters.
 
-By implementing a new adapter, *Developer A* allows *Product A* to fit into the workflow.  
+_User A_ would like to:
+
+1. Submit one STIX pattern to query all the user’s security products at once. The use of a STIX pattern simplifies the search process because _User A_ does not need to know the query language or API calls for each security product.
+1. See the query results from all the security products in one unified format (STIX bundle). With the assumption that the submitted pattern represents a potential security incident, the STIX bundle presents the query results in the context of the security event.
+
+By implementing a new adapter, _Developer A_ allows _Product A_ to fit into the workflow.
 
 ## Prerequisites
 
-* Your development environment must use Python 3.6.
-* You must have access to the target data source. In the sample scenario, you must have access to Product A data source.
-* You must be familiar with Product A's query language and APIs.
-* You must be familiar or understand the following concepts:
-    * Observable objects. See [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html)
-    * Stix patterning. See [STIX™ Version 2.0. Part 5: STIX Patterning](https://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part5-stix-patterning.html)
-
+- Your development environment must use Python 3.6.
+- You must have access to the target data source. In the sample scenario, you must have access to Product A data source.
+- You must be familiar with Product A's query language and APIs.
+- You must be familiar or understand the following concepts:
+  - Observable objects. See [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html)
+  - Stix patterning. See [STIX™ Version 2.0. Part 5: STIX Patterning](https://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part5-stix-patterning.html)
 
 ## Steps
 
 To develop a STIX-shifter adapter for a data source:
 
 1. Fork the `IBM/stix-shifter` repository from https://github.com/IBM/stix-shifter to work on your own copy of the library.
-1. [Create a Translation module](#create-a-translation-module). 
+1. [Create a Translation module](#create-a-translation-module).
 1. [Create a Transmission module](#create-a-transmission-module).
 1. Create a pull request to merge your changes in the `IBM/stix-shifter` repository.
 
 ### Create a Translation module
 
 1. [Create a translation module folder](#step-1-create-a-translation-module-folder)
-1. [Rename the dummy_translator.py file](#step-2-rename-the-dummy-translator-file) 
-1. [Edit the from_stix_map.json file](#step-3-edit-the-from_stix_map-json-file) 
+1. [Rename the dummy_translator.py file](#step-2-rename-the-dummy-translator-file)
+1. [Edit the from_stix_map.json file](#step-3-edit-the-from_stix_map-json-file)
 1. [Edit the query_constructor.py file](#step-4-edit-the-query-constructor-file)
 1. [Edit the to_stix_map.json file](#step-5-edit-the-to_stix_map-json-file)
 1. [If required by your data source, update the transformers.py file](#step-6-if-required-by-your-data-source-update-the-transformers-file)
 1. [Update the MANIFEST.in file to include the path to the json mapping folder](#step-7-update-the-manifest-file-to-include-the-path-to-the-json-mapping-folder)
-1. [Verify that the translation module was created successfully](#step-8-verify-that-the-translation-module-was-created-successfully) 
+1. [Verify that the translation module was created successfully](#step-8-verify-that-the-translation-module-was-created-successfully)
 
 #### Step 1. Create a translation module folder
 
-1.	Go to `stix_shifter/stix_translation/src/modules/`.
-2.	Copy the `dummy` translation module folder. It is a template to help you get started quickly. It contains the necessary files that your translation module needs. You need to customize it based on your data source. 
+1. Go to `stix_shifter/stix_translation/src/modules/`.
+2. Copy the `dummy` translation module folder. It is a template to help you get started quickly. It contains the necessary files that your translation module needs. You need to customize it based on your data source.
 
 ![Translation module dummy folder](./images/translation-module-dummy-folder.png)
 
-3.	Rename your `dummy` translation module folder to match the name of your data source. For example, `abc`. 
+3. Rename your `dummy` translation module folder to match the name of your data source. For example, `abc`.
 
-    The data source name is used as an argument when either translation or transmission is called. This argument is used throughout the project so that STIX-shifter knows which modules to use. 
+   The data source name is used as an argument when either translation or transmission is called. This argument is used throughout the project so that STIX-shifter knows which modules to use.
 
-    **Note:** The translation and transmission modules must have the same name.
-4.	Verify that your translation module folder contains the following folders and files. 
+   **Note:** The translation and transmission modules must have the same name.
 
-| Folder/file             | Why is it important? Where is it used?
-| ------------------------| --------------------------------------
-| json/from_stix_map.json | This mapping file is used to translate a STIX pattern to a data source query result.
-| json/to_stix_map.json   | This mapping file is used to translate a data source query result into STIX objects.
-| __init__.py             | This file is required by Python to properly handle library directories.
-| data_mapping.py         | This file uses the mappings that are defined in the from_stix_map.json file to map the STIX objects and their properties to field names from the data source.
-| dummy_translator.py     | This file contains the Translator class. It inherits the BaseTranslator abstract base class and is the interface to the rest of the translation logic.
-| query_constructor.py    | This file contains the QueryStringPatternTranslator class, which translates the ANTLR parsing of the STIX pattern to the native data source query.
-| stix_to_query.py        | This file contains the StixToQuery class, which inherits the BaseQueryTranslator class. <br><br>StixToQuery calls out to the ANTLR parser, which returns a parsing of the STIX pattern. The parsing is then passed onto the query_constructor.py where it is translated into the native data source query. 
-| transformers.py         | This file is used to transform data formats as required by STIX and the native data source query language. 
-| MANIFEST.in             | This file is used by Python when packaging the library. 
+4. Verify that your translation module folder contains the following folders and files.
+
+| Folder/file             | Why is it important? Where is it used?                                                                                                                                                                                                                                                                     |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| json/from_stix_map.json | This mapping file is used to translate a STIX pattern to a data source query result.                                                                                                                                                                                                                       |
+| json/to_stix_map.json   | This mapping file is used to translate a data source query result into STIX objects.                                                                                                                                                                                                                       |
+| **init**.py             | This file is required by Python to properly handle library directories.                                                                                                                                                                                                                                    |
+| data_mapping.py         | This file uses the mappings that are defined in the from_stix_map.json file to map the STIX objects and their properties to field names from the data source.                                                                                                                                              |
+| dummy_translator.py     | This file contains the Translator class. It inherits the BaseTranslator abstract base class and is the interface to the rest of the translation logic.                                                                                                                                                     |
+| query_constructor.py    | This file contains the QueryStringPatternTranslator class, which translates the ANTLR parsing of the STIX pattern to the native data source query.                                                                                                                                                         |
+| stix_to_query.py        | This file contains the StixToQuery class, which inherits the BaseQueryTranslator class. <br><br>StixToQuery calls out to the ANTLR parser, which returns a parsing of the STIX pattern. The parsing is then passed onto the query_constructor.py where it is translated into the native data source query. |
+| transformers.py         | This file is used to transform data formats as required by STIX and the native data source query language.                                                                                                                                                                                                 |
+| MANIFEST.in             | This file is used by Python when packaging the library.                                                                                                                                                                                                                                                    |
 
 [Back to top](#create-a-translation-module)
 
 #### Step 2. Rename the dummy translator file
 
-* In your `abc` translation module folder, rename the `dummy_translator.py` file to  [module_name]_translator.py. 
-* The [module_name] must match the name that you assigned to your module folder in step 1. For example, `abc_translator.py`. 
+- In your `abc` translation module folder, rename the `dummy_translator.py` file to [module_name]\_translator.py.
+- The [module_name] must match the name that you assigned to your module folder in step 1. For example, `abc_translator.py`.
 
-    When STIX-shifter is used to translate to or from STIX, the data source name is passed in as an argument. This argument is used to determine which module and files to use. If the name of the translator doesn't match the name of the module, an error occurs when the new translation module is used.
+  When STIX-shifter is used to translate to or from STIX, the data source name is passed in as an argument. This argument is used to determine which module and files to use. If the name of the translator doesn't match the name of the module, an error occurs when the new translation module is used.
 
-    ![dummy-translator.py file](./images/dummy-translator.py.png)
+  ![dummy-translator.py file](./images/dummy-translator.py.png)
 
-[Back to top](#create-a-translation-module)    
+[Back to top](#create-a-translation-module)
 
 #### Step 3. Edit the from_stix_map JSON file
 
-The `from_stix_map.json` file is where you define HOW to translate a STIX pattern to a data source query result. STIX patterns are expressions that represent Cyber Observable objects. The mapping of STIX objects and their properties to data source fields, determine how a STIX pattern is translated to a data source query. Only STIX objects and properties that have mappings can be used in a STIX pattern. 
+The `from_stix_map.json` file is where you define HOW to translate a STIX pattern to a data source query result. STIX patterns are expressions that represent Cyber Observable objects. The mapping of STIX objects and their properties to data source fields, determine how a STIX pattern is translated to a data source query. Only STIX objects and properties that have mappings can be used in a STIX pattern.
 
-If a STIX pattern contains an unmapped property, STIX-shifter produces an error when translation is called. The error happens because the QueryStringPatternTranslator class (in query_constructor.py) does not know what data source field the STIX object property must be converted to. 
+If a STIX pattern contains an unmapped property, STIX-shifter produces an error when translation is called. The error happens because the QueryStringPatternTranslator class (in query_constructor.py) does not know what data source field the STIX object property must be converted to.
 
-1.	Identify your data source fields.
-2.	Refer to the following documentation [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for the list of STIX objects that you can map your data source fields.
-3.	In your `abc` translation module folder, go to your json/ subfolder and edit the `from_stix_map.json` file. The `from_stix_map.json` file contains a sample mapping of STIX objects and properties to data source fields in the following format:
-    ```
-    {
-        "stix-object": {
-            "fields": {
-                "stix_object_property": ["DataSourceField", "DataSourceField"],
-                "stix_object_property": ["DataSourceField"]
-            }
-        }
-    }
-    ```
-4.	Map your data source fields to a STIX object and property. Define the mapping based on the specified format. You can map multiple data source fields to the same STIX object property.
-    * "stix-object" refer to a STIX cyber observable object type name
-    * "stix_object_property" refers to a STIX cyber observable object property name
+1. Identify your data source fields.
+2. Refer to the following documentation [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for the list of STIX objects that you can map your data source fields.
+3. In your `abc` translation module folder, go to your json/ subfolder and edit the `from_stix_map.json` file. The `from_stix_map.json` file contains a sample mapping of STIX objects and properties to data source fields in the following format:
+   ```
+   {
+       "stix-object": {
+           "fields": {
+               "stix_object_property": ["DataSourceField", "DataSourceField"],
+               "stix_object_property": ["DataSourceField"]
+           }
+       }
+   }
+   ```
+4. Map your data source fields to a STIX object and property. Define the mapping based on the specified format. You can map multiple data source fields to the same STIX object property.
+   - "stix-object" refer to a STIX cyber observable object type name
+   - "stix_object_property" refers to a STIX cyber observable object property name
 
 **Example mapping**
 
@@ -178,9 +181,9 @@ Pattern[
 ]
 ```
 
-The parsing is recursively run through QueryStringPatternTranslator._parse_expression, which is found in `query_constructor.py`.
+The parsing is recursively run through QueryStringPatternTranslator.\_parse_expression, which is found in `query_constructor.py`.
 
-The `query_constructor.py` file is where the native query is built from the ANTLR parsing. 
+The `query_constructor.py` file is where the native query is built from the ANTLR parsing.
 
 In your `abc` translation module folder, edit the `query_constructor.py` file. Update the following sections based on the requirements of your data source.
 
@@ -188,33 +191,34 @@ In your `abc` translation module folder, edit the `query_constructor.py` file. U
 
 The comparator_lookup maps the STIX pattern operators to the data source query operators. Change the comparator values to match the operators supported in your data source.
 
-The default operators that are defined in your translation module are the ones that are used in an SQL query. 
+The default operators that are defined in your translation module are the ones that are used in an SQL query.
 
 ![Comparator lookup mapping](./images/comparator-lookup-mapping.png)
- 
-| STIX pattern operators                            | Data source query operators
-| --------------------------------------------------| --------------------------------------
-| ComparisonExpressionOperators.And                 | 	And
-| ComparisonExpressionOperators.Or	                | OR
-| ComparisonExpressionOperators.GreaterThan         | >
-| ComparisonExpressionOperators.GreaterThanOrEqual  | >=
-| ComparisonExpressionOperators.LessThan            | <
-| ComparisonComparators.LessThanOrEqual             | <=
-| ComparisonComparators.Equal                       | =
-| ComparisonComparators.NotEqual                    | !=
-| ComparisonComparators.Like                        | LIKE
-| ComparisonComparators.In                          | IN
-| ComparisonComparators.Matches                     | LIKE
 
-##### 2. Define the _parse_expression method
+| STIX pattern operators                           | Data source query operators |
+| ------------------------------------------------ | --------------------------- |
+| ComparisonExpressionOperators.And                | And                         |
+| ComparisonExpressionOperators.Or                 | OR                          |
+| ComparisonExpressionOperators.GreaterThan        | >                           |
+| ComparisonExpressionOperators.GreaterThanOrEqual | >=                          |
+| ComparisonExpressionOperators.LessThan           | <                           |
+| ComparisonComparators.LessThanOrEqual            | <=                          |
+| ComparisonComparators.Equal                      | =                           |
+| ComparisonComparators.NotEqual                   | !=                          |
+| ComparisonComparators.Like                       | LIKE                        |
+| ComparisonComparators.In                         | IN                          |
+| ComparisonComparators.Matches                    | LIKE                        |
 
-The ANTLR parsing is recursively run through the _parse_expression method. The type of expression is determined on each iteration. When the expression is a ComparisonExpression, a query string is added to the final data source query. 
+##### 2. Define the \_parse_expression method
+
+The ANTLR parsing is recursively run through the \_parse_expression method. The type of expression is determined on each iteration. When the expression is a ComparisonExpression, a query string is added to the final data source query.
 
 This image illustrates where the query string is constructed for the data source query.
 
 ![Parse expression method](./images/parse-expression-method.png)
 
 The following ComparisonExpression from an ANTLR parsing:
+
 ```
 ComparisonExpression(
    network-traffic:src_port ComparisonComparators.Equal 37020
@@ -226,10 +230,11 @@ Would add the following string to the native query:
 
 ##### 3. Define the final query that gets returned in the translate_pattern method
 
-Depending on your data source, edit this section to: 
-* Add a query field selector.
-* Append result limits and time windows.
-* Return an array of queries or a single query string. A single query string is returned by default, but queries can be split into an array of query strings if required.
+Depending on your data source, edit this section to:
+
+- Add a query field selector.
+- Append result limits and time windows.
+- Return an array of queries or a single query string. A single query string is returned by default, but queries can be split into an array of query strings if required.
 
 [Back to top](#create-a-translation-module)
 
@@ -238,27 +243,28 @@ Depending on your data source, edit this section to:
 The `to_stix_map.json` file is where you define HOW to translate data source query results into a bundle of STIX objects. Query results must be in JSON format; otherwise, the data source cannot be supported.
 
 Results from unmapped data source fields are ignored during translation and are not included in the bundle.
-1.	Identify your data source fields.
-2.	Refer to the following documentation [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for the list of STIX objects that you can map your data source fields.
-3.	In your `abc` translation module folder, go to your json/ subfolder and edit the `to_stix_map.json` file. The `to_stix_map.json` file contains a sample mapping of data source fields to STIX objects and properties in the following format:
 
-    ```
-    {
-        "DataSourceField": {
-            "key": "stix-object.stix_object_property"
-        },
-        "DataSourceField": {
-            "key": "x_custom_object.property",
-            "cybox": false
-        }
-    }
-    ```
+1. Identify your data source fields.
+2. Refer to the following documentation [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for the list of STIX objects that you can map your data source fields.
+3. In your `abc` translation module folder, go to your json/ subfolder and edit the `to_stix_map.json` file. The `to_stix_map.json` file contains a sample mapping of data source fields to STIX objects and properties in the following format:
 
-4.	Each JSON object in the mapping has a "key" element with a value that represents a STIX object and its property. Define the mapping based on the specified format. 
-    * `stix-object` refer to a STIX cyber observable object type name
-    * `stix_object_property` refers to a STIX cyber observable object property name
-    * `x_custom_object.property` refers to a custom object and its property that you can use for fields that don't map to any STIX objects
-    * Mappings for custom properties must have a `cybox` key set to false. This setting identifies custom objects during the translation process.
+   ```
+   {
+       "DataSourceField": {
+           "key": "stix-object.stix_object_property"
+       },
+       "DataSourceField": {
+           "key": "x_custom_object.property",
+           "cybox": false
+       }
+   }
+   ```
+
+4. Each JSON object in the mapping has a "key" element with a value that represents a STIX object and its property. Define the mapping based on the specified format.
+   - `stix-object` refer to a STIX cyber observable object type name
+   - `stix_object_property` refers to a STIX cyber observable object property name
+   - `x_custom_object.property` refers to a custom object and its property that you can use for fields that don't map to any STIX objects
+   - Mappings for custom properties must have a `cybox` key set to false. This setting identifies custom objects during the translation process.
 
 **Example mapping**
 Using the same data source as in step 3, the following example shows a to-STIX mapping:
@@ -308,32 +314,54 @@ Using the same data source as in step 3, the following example shows a to-STIX m
     "LogSourceId": {
         "key": "x_my_data_source.log_source",
         "cybox": false
-    }
+    },
+    "EventTime": [
+        {
+            "key": "created",
+            "cybox": false
+        },
+        {
+            "key": "modified",
+            "cybox": false
+        },
+        {
+            "key": "first_observed",
+            "cybox": false
+        },
+        {
+            "key": "last_observed",
+            "cybox": false
+        }
+    ]
 }
 ```
 
 **About the example mapping**
-* Url is a simple mapping. 
-* SourcePort and DestinationPort 
-    * Have matching "object" values, which cause the src_port and dst_port to be added to the same object (in this case, network-traffic). 
-    * Uses the ToInteger transformer. Transformers are optional mapping attributes that apply a transformation method to the data before it is written to the STIX object. The existing transform methods are in `stix_shifter/stix_translation/src/transformers.py`. Any new transformers must be added to this file.
-* SourceIpV4 and DestinationIpV4 contain two objects. 
-    * The first object creates an ipv4-addr object for each of the values. Given the field, the "object" property is set to either src_ip or dst_ip. 
-    * The second object in the mapping adds references in the network-traffic object to the ipv4-addr objects. Since the second part of the mappings has the object set to "nt", the references are added to the same network-traffic object that contains the source and destination ports.
-* NetworkProtocol 
-    * Mapped similarly to the source and destination ports. 
-    * Note the use of the ToLowercaseArray transformer. The example data source returns a single string in the NetworkProtocol field. However, in STIX, network-traffic protocols store an array of protocols in lowercase format.
-* LogSourceId 
-    * An example of a custom STIX property. 
-    * Custom properties allow for data that would not fit in any existing STIX object type to be added to the observed-data object. Custom properties must start with an x_. In this example, the data source name is used as the custom object name and log_source is the custom property. 
+
+- Url is a simple mapping.
+- SourcePort and DestinationPort
+  - Have matching "object" values, which cause the src_port and dst_port to be added to the same object (in this case, network-traffic).
+  - Uses the ToInteger transformer. Transformers are optional mapping attributes that apply a transformation method to the data before it is written to the STIX object. The existing transform methods are in `stix_shifter/stix_translation/src/transformers.py`. Any new transformers must be added to this file.
+- SourceIpV4 and DestinationIpV4 contain two objects.
+  - The first object creates an ipv4-addr object for each of the values. Given the field, the "object" property is set to either src_ip or dst_ip.
+  - The second object in the mapping adds references in the network-traffic object to the ipv4-addr objects. Since the second part of the mappings has the object set to "nt", the references are added to the same network-traffic object that contains the source and destination ports.
+- NetworkProtocol
+  - Mapped similarly to the source and destination ports.
+  - Note the use of the ToLowercaseArray transformer. The example data source returns a single string in the NetworkProtocol field. However, in STIX, network-traffic protocols store an array of protocols in lowercase format.
+- LogSourceId
+  - An example of a custom STIX property.
+  - Custom properties allow for data that would not fit in any existing STIX object type to be added to the observed-data object. Custom properties must start with an x\_. In this example, the data source name is used as the custom object name and log_source is the custom property.
+- EventTime
+  - Data source field indicating the time of the event.
+  - Maps to the following STIX fields: created, modified, first_observed, last_observed
 
 **Example observed-data STIX object**
 
 **Input data**
 
-| Url	            | SourcePort | DestinationPort	| SourceIpV4 | DestinationIpV4 | NetworkProtocol | LogSourceId
-| ----------------- | ---------- | ---------------- | ---------- | --------------- | --------------- | ------------
-| www.example.com	| 3000	     | 1000	            | 192.0.2.0	 | 198.51.100.0    | TCP	         | 678
+| Url             | SourcePort | DestinationPort | SourceIpV4 | DestinationIpV4 | NetworkProtocol | LogSourceId | EventTime                |
+| --------------- | ---------- | --------------- | ---------- | --------------- | --------------- | ----------- | ------------------------ |
+| www.example.com | 3000       | 1000            | 192.0.2.0  | 198.51.100.0    | TCP             | 678         | 2019-04-24T12:44:00.605Z |
 
 **Output**
 
@@ -344,6 +372,11 @@ The following illustrates an observed-data STIX object that is derived from the 
       "id": "observed-data--6ecb744f-37d2-4950-a7bb-9dc821679c52",
       "type": "observed-data",
       "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "created": "2019-04-24T12:44:00.605Z",
+      "first_observed": "2019-04-24T12:44:00.605Z",
+      "last_observed": "2019-04-24T12:44:00.605Z",
+      "modified": "2019-04-24T12:44:00.605Z",
+      "number_observed": 1,
       "objects": {
         "0": {
           "type": "ipv4-addr",
@@ -369,7 +402,11 @@ The following illustrates an observed-data STIX object that is derived from the 
         "log_source": 678
       }
     }
-```    
+```
+
+**Required fields:**
+
+Every STIX observed-data object must include the following fields: id, type, created_by_ref, created, modified, first_observed, last_observed, and number_observed.
 
 The code for translating data source results to STIX is found in `stix_shifter/stix_translation/src/json_to_stix/json_to_stix_translator.py`. Normally, there is no need to edit this file.
 
@@ -377,10 +414,10 @@ The code for translating data source results to STIX is found in `stix_shifter/s
 
 #### Step 6. If required by your data source, update the transformers file
 
-The `transformers.py` file contains classes that transform data formats. Each class has a method that takes in data and transforms it into the preferred format. For example, an integer value is transformed into a string. These classes can be used in cases such as: 
+The `transformers.py` file contains classes that transform data formats. Each class has a method that takes in data and transforms it into the preferred format. For example, an integer value is transformed into a string. These classes can be used in cases such as:
 
-* When converting from STIX, the data source query language requires specific data formats. For example, time stamps. In this case, the format of a value in the STIX pattern must be transformed during pattern translation if the STIX and query language data formats are different. 
-* When converting to STIX, the STIX object requires specific data formats. In this case, the format of a value that is returned in the data source results must be transformed during translation into a bundle of STIX objects. See [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for STIX data formats.
+- When converting from STIX, the data source query language requires specific data formats. For example, time stamps. In this case, the format of a value in the STIX pattern must be transformed during pattern translation if the STIX and query language data formats are different.
+- When converting to STIX, the STIX object requires specific data formats. In this case, the format of a value that is returned in the data source results must be transformed during translation into a bundle of STIX objects. See [STIX™ Version 2.0. Part 4: Cyber Observable Objects](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) for STIX data formats.
 
 [Back to top](#create-a-translation-module)
 
@@ -396,40 +433,42 @@ You must have access to the data source either through a UI or CLI so that you c
 The translation module can be tested by calling the `main.py file` from the command line and passing in the required arguments. The order of arguments is as follows:
 
 ```
-python main.py translate <data source (module) name> <"query" or "result"> <STIX identity object> <pattern or JSON results to 
+python main.py translate <data source (module) name> <"query" or "result"> <STIX identity object> <pattern or JSON results to
 be translated> <options>
 ```
 
 ##### Test the STIX pattern to data source query translation
 
-1.	Run the translation module from the command line. For example, using abc as a data source:
+1. Run the translation module from the command line. For example, using abc as a data source:
 
 ```
 python main.py translate abc query '{}' "[network-traffic:src_port = 37020 and network-traffic:dst_port = 635] OR [ipv4-addr:value = '333.333.333.0'] AND [url:value = 'www.example.com'] START t'2019-01-28T12:24:01.009Z' STOP t'2019-01-28T12:54:01.009Z'"
 ```
 
-2.	Visually verify the returned query by running it against the data source.
+2. Visually verify the returned query by running it against the data source.
 
 ##### Test the JSON data source results to STIX translation
 
-1.	Run the translation module from the command line. For example, using abc as a data source:
+1. Run the translation module from the command line. For example, using abc as a data source:
 
 ```
 python main.py translate abc results '{"type": "identity","id": "identity--f431f809-377b-45e0-aa1c-
 6a4751cae5ff","name": "abc","identity_class": "events"}' '[{"Url": "www.example.com", "SourcePort": 3000, "DestinationPort": 1000, "SourceIpV4": "192.0.2.0", "DestinationIpV4": "198.51.100.0", "NetworkProtocol": "TCP"}]'
 ```
 
-2.	Visually verify that all expected data is in the returned STIX bundle. If a data source field in your sample results is mapped in `to_stix_map.json`, the value must be in the STIX bundle under the mapped STIX property.
+2. Visually verify that all expected data is in the returned STIX bundle. If a data source field in your sample results is mapped in `to_stix_map.json`, the value must be in the STIX bundle under the mapped STIX property.
 
-**Note:** 
-* The `<STIX identity object>` represents a data source and is the first observed-data object that gets added to the STIX bundle during results translation. 
-* Each observed-data object, which gets added to the bundle, references the `<STIX identity object>` to indicate which data source the result came from. 
-* The `<STIX identity object>` is only used when translating data source results to STIX. As such, an empty JSON object can be passed in when converting a STIX pattern to a data source query. 
-* For more information about identity objects, see the [STIX 2 documentation](http://docs.oasis-open.org/cti/stix/v2.0/cs01/part2-stix-objects/stix-v2.0-cs01-part2-stix-objects.html#_Toc496714310).
+**Note:**
+
+- The `<STIX identity object>` represents a data source and is the first observed-data object that gets added to the STIX bundle during results translation.
+- Each observed-data object, which gets added to the bundle, references the `<STIX identity object>` to indicate which data source the result came from.
+- The `<STIX identity object>` is only used when translating data source results to STIX. As such, an empty JSON object can be passed in when converting a STIX pattern to a data source query.
+- For more information about identity objects, see the [STIX 2 documentation](http://docs.oasis-open.org/cti/stix/v2.0/cs01/part2-stix-objects/stix-v2.0-cs01-part2-stix-objects.html#_Toc496714310).
 
 [Back to top](#create-a-translation-module)
 
 ### Create a Transmission module
+
 {: #transmission-mod}
 
 1. [Create a transmission module folder](#step-1-create-a-transmission-module-folder)
@@ -439,86 +478,93 @@ python main.py translate abc results '{"type": "identity","id": "identity--f431f
 
 #### Step 1. Create a transmission module folder
 
-1.	Go to `stix_shifter/stix_transmission/src/modules/`.
-2.	Copy the `async_dummy` or `synchronous_dummy` folder, whichever is appropriate for your data source, based on the data source API. 
+1. Go to `stix_shifter/stix_transmission/src/modules/`.
+2. Copy the `async_dummy` or `synchronous_dummy` folder, whichever is appropriate for your data source, based on the data source API.
 
-    These dummy folders are templates to help you get started quickly. They contain the necessary files that your transmission module needs. You need to customize it based on your data source. 
-3.	Rename your `async_dummy` or `synchronous_dummy` transmission module folder to match the name of your data source. It must match the same name that you assigned for your translation module. For example, abc. 
+   These dummy folders are templates to help you get started quickly. They contain the necessary files that your transmission module needs. You need to customize it based on your data source.
 
-    The data source name is used as an argument when either translation or transmission is called. This argument is used throughout the project so that STIX-shifter knows which modules to use. 
+3. Rename your `async_dummy` or `synchronous_dummy` transmission module folder to match the name of your data source. It must match the same name that you assigned for your translation module. For example, abc.
 
-    **Note:** The translation and transmission modules must have the same name.
+   The data source name is used as an argument when either translation or transmission is called. This argument is used throughout the project so that STIX-shifter knows which modules to use.
 
-4.	Verify that your transmission module folder contains the following folders and files. 
+   **Note:** The translation and transmission modules must have the same name.
 
-    For an asynchronous transmission module, you must have the following files:
+4. Verify that your transmission module folder contains the following folders and files.
 
-    | Folder/file	            | Why is it important? Where is it used?
-    | ------------------------- |-----------------------------
-    | __init__.py               |This file is required by Python to properly handle library directories.
-    | apiclient.py		        |
-    | async_dummy_connector.py	| 
+   For an asynchronous transmission module, you must have the following files:
 
-    For a synchronous transmission module, you must have the following files:
+   | Folder/file              | Why is it important? Where is it used?                                  |
+   | ------------------------ | ----------------------------------------------------------------------- |
+   | **init**.py              | This file is required by Python to properly handle library directories. |
+   | apiclient.py             |
+   | async_dummy_connector.py |
 
-    | Folder/file	                 | Why is it important? Where is it used?
-    | ------------------------------ |-----------------------------
-    | __init__.py                    |This file is required by Python to properly handle library directories.
-    | synchronous_dummy_connector.py |	
+   For a synchronous transmission module, you must have the following files:
+
+   | Folder/file                    | Why is it important? Where is it used?                                  |
+   | ------------------------------ | ----------------------------------------------------------------------- |
+   | **init**.py                    | This file is required by Python to properly handle library directories. |
+   | synchronous_dummy_connector.py |
 
 [Back to top](#create-a-transmission-module)
 
 #### Step 2. Edit the apiclient file
 
-You can implement an API client for an asynchronous or a synchronous data source.  If your data source has a simpler way of calling the APIs, you don’t need an API client and you can skip this step.
+You can implement an API client for an asynchronous or a synchronous data source. If your data source has a simpler way of calling the APIs, you don’t need an API client and you can skip this step.
 
 Edit the `apiclient.py` file's APIClient class to include the methods to call your data source' APIs. Each method calls out to the relevant API.
-* At a minimum, methods must be implemented for:
-    * Pinging the data source
-    * Creating a search; sending a query to the data source
-    * Checking the status of a search (only used for asynchronous data sources)
-    * Retrieving search results (only used for asynchronous data sources)
-* You can add methods for the following and others, if supported by your data source:
-    * Updating a search
-    * Deleting a search
 
-[Back to top](#create-a-transmission-module)    
+- At a minimum, methods must be implemented for:
+  - Pinging the data source
+  - Creating a search; sending a query to the data source
+  - Checking the status of a search (only used for asynchronous data sources)
+  - Retrieving search results (only used for asynchronous data sources)
+- You can add methods for the following and others, if supported by your data source:
+  - Updating a search
+  - Deleting a search
+
+[Back to top](#create-a-transmission-module)
 
 #### Step 3. Edit the dummy connector file
 
-1.	In your abc transmission module folder, rename the `async_dummy_connector.py` file or `synchronous_dummy_connector.py` file to <module_name>_connector.py. 
+1. In your abc transmission module folder, rename the `async_dummy_connector.py` file or `synchronous_dummy_connector.py` file to <module_name>\_connector.py.
 
-    The `dummy_connector.py` file contains the Connector class, which gets instantiated when the transmission module is invoked. The Connector class contains all the methods that call out to the data source API through the API client.
+   The `dummy_connector.py` file contains the Connector class, which gets instantiated when the transmission module is invoked. The Connector class contains all the methods that call out to the data source API through the API client.
 
-    The <module_name> must match the name that you assigned to your module folder in step 1. For example, abc_connector.py. 
+   The <module_name> must match the name that you assigned to your module folder in step 1. For example, abc_connector.py.
 
-    When STIX-shifter uses a transmission module to connect to a data source, the data source name is passed in as an argument. This argument is used to determine which module and files to use. If the argument name doesn't match the name of the module, an error occurs when the new transmission module is used.
-2.	Edit the `abc_connector.py` file's Connector(BaseConnector) class to include the methods to run each of the API client methods. 
-    * Change each method implementation as needed. Keep method names and signatures as they are.
-    * You can add the methods in the same file or create individual files for each. 
-    * At a minimum, methods must be implemented for:
-        * ping
-        * create_query_connection (only used for asynchronous data sources)
-        * create_status_connection (only used for asynchronous data sources)
-        * create_results_connection
+   When STIX-shifter uses a transmission module to connect to a data source, the data source name is passed in as an argument. This argument is used to determine which module and files to use. If the argument name doesn't match the name of the module, an error occurs when the new transmission module is used.
 
-            **Note:** The data source results need to be in JSON format before they are converted into STIX. If the results are not returned as JSON, the create_results_connection is one place where any needed JSON conversion might take place.
-    * You can add other methods, if supported by your data source. For example, delete_query_connection.
+2. Edit the `abc_connector.py` file's Connector(BaseConnector) class to include the methods to run each of the API client methods.
+
+   - Change each method implementation as needed. Keep method names and signatures as they are.
+   - You can add the methods in the same file or create individual files for each.
+   - At a minimum, methods must be implemented for:
+
+     - ping
+     - create_query_connection (only used for asynchronous data sources)
+     - create_status_connection (only used for asynchronous data sources)
+     - create_results_connection
+
+       **Note:** The data source results need to be in JSON format before they are converted into STIX. If the results are not returned as JSON, the create_results_connection is one place where any needed JSON conversion might take place.
+
+   - You can add other methods, if supported by your data source. For example, delete_query_connection.
 
 **Note on synchronous data sources**
 
 For synchronous data sources, the query is sent to the API from the create_results_connection method. The query is sent, and the results are received in the same step. Although create_query_connection, and create_status_connection are not technically used, they still get called during the transmission execution and must be implemented as follows:
 
-*Create Query Connection*
+_Create Query Connection_
 
 ```
-def create_query_connection(self, query): 
+def create_query_connection(self, query):
       return { "success": True, "search_id": query }
-```      
-
-*Create Status Connection*
 ```
-def create_status_connection(self, search_id): 
+
+_Create Status Connection_
+
+```
+def create_status_connection(self, search_id):
       return {"success": True, "status": "COMPLETED", "progress": 100}
 ```
 
@@ -526,82 +572,94 @@ def create_status_connection(self, search_id):
 
 #### Step 4. Verify that the transmission module was created successfully
 
-1.	You must have:
-    * Authentication credentials to connect to the data source.
-    * A private key and certificate for the cert.
+1. You must have:
 
-    Authentication depends on the data source and can be: 
-    ```
-    '{"auth": {"username": "<username>","password": "<password>"}}' or
-    '{"auth": {"SEC":"<SEC TOKEN>"}}'
-    ```
+   - Authentication credentials to connect to the data source.
+   - A private key and certificate for the cert.
 
-2.	Test the transmission ping method.  
-    1. Use the following CLI command:    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' ping
-        ```
-    
-    2. Visually confirm that a result comes back with 
-        ```
-        {'success': True}
-        ```
+   Authentication depends on the data source and can be:
 
-3.	Test the transmission is_async method.  
-    1. Use the following CLI command:    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' is_async
-        ```
-    2. Visually confirm that it returns true if the data source is asynchronous. Otherwise, it must return false.
+   ```
+   '{"auth": {"username": "<username>","password": "<password>"}}' or
+   '{"auth": {"SEC":"<SEC TOKEN>"}}'
+   ```
 
-4.	Test the transmission query method.  
-    1. Use the following CLI command:    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' query "<Native data source Query String>"
-        ```
+2. Test the transmission ping method.
 
-    2. Visually confirm that a result comes back with 
-        ```
-        {'success': True, 'search_id': '<some query UUID>'}
-        ```
+   1. Use the following CLI command:
 
-    3. Take note of the UUID that is returned. It is the ID to use in the rest of the tests.
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' ping
+      ```
 
-5.	Test the transmission status method.  
-    1. Use the following CLI command:    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' status "<Query UUID from test 4>"
-        ```
-        
-    2. Visually confirm that a result comes back with 
-        ```
-        {'success': True, 'status': 'COMPLETED', 'progress': 100}
-        ```
+   2. Visually confirm that a result comes back with
+      ```
+      {'success': True}
+      ```
 
-6.	Test the transmission results method.  
-    1. Use the following CLI command:
-    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' results "<Query UUID from test 4>" <Offset Integer> <Length Integer>
-        ```
+3. Test the transmission is_async method.
 
-    2. You can set the offset and length command line arguments to 1. 
-    3. Visually confirm that query results are returned as JSON objects. These results can be compared to what is returned when running the query string used in test C directly on the data source API, either through a UI or the CLI.
+   1. Use the following CLI command:
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' is_async
+      ```
+   2. Visually confirm that it returns true if the data source is asynchronous. Otherwise, it must return false.
 
-7.	Test the transmission delete method if the data source supports it.  
-    1. Use the following CLI command:
-    
-        ```
-        python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert": 
-        "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' delete "<Query UUID from test 4>"
-        ```
+4. Test the transmission query method.
 
-    2. Visually confirm that a result comes back with 
-        ```
-        {'success': True}
-        ```
+   1. Use the following CLI command:
+
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' query "<Native data source Query String>"
+      ```
+
+   2. Visually confirm that a result comes back with
+
+      ```
+      {'success': True, 'search_id': '<some query UUID>'}
+      ```
+
+   3. Take note of the UUID that is returned. It is the ID to use in the rest of the tests.
+
+5. Test the transmission status method.
+
+   1. Use the following CLI command:
+
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' status "<Query UUID from test 4>"
+      ```
+
+   2. Visually confirm that a result comes back with
+      ```
+      {'success': True, 'status': 'COMPLETED', 'progress': 100}
+      ```
+
+6. Test the transmission results method.
+
+   1. Use the following CLI command:
+
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth{"auth": <authentication object>}' results "<Query UUID from test 4>" <Offset Integer> <Length Integer>
+      ```
+
+   2. You can set the offset and length command line arguments to 1.
+   3. Visually confirm that query results are returned as JSON objects. These results can be compared to what is returned when running the query string used in test C directly on the data source API, either through a UI or the CLI.
+
+7. Test the transmission delete method if the data source supports it.
+
+   1. Use the following CLI command:
+
+      ```
+      python main.py transmit abc '{"host":"<IP address or URL to data source>", "port":"<port number>", "cert":
+      "-----BEGIN PRIVATE KEY-----<private key>-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----<certificate>-----END CERTIFICATE-----\n"}' '{"auth": <authentication object>}' delete "<Query UUID from test 4>"
+      ```
+
+   2. Visually confirm that a result comes back with
+      ```
+      {'success': True}
+      ```

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ def __main__():
     translate_parser.add_argument(
         'module', choices=stix_translation.TRANSLATION_MODULES, help='The translation module to use')
     translate_parser.add_argument('translate_type', choices=[
-        stix_translation.RESULTS, stix_translation.QUERY], help='The translation action to perform')
+        stix_translation.RESULTS, stix_translation.QUERY, stix_translation.PARSE], help='The translation action to perform')
     translate_parser.add_argument(
         'data_source', help='STIX identity object representing a datasource')
     translate_parser.add_argument(

--- a/tests/bigfix_tests/test_stix_to_relevance.py
+++ b/tests/bigfix_tests/test_stix_to_relevance.py
@@ -4,9 +4,8 @@ import unittest
 translation = stix_translation.StixTranslation()
 
 
-def _test_query_assertions(query, queries, parsed_stix):
+def _test_query_assertions(query, queries):
     assert query['queries'] == queries
-    assert query['parsed_stix'] == parsed_stix
 
 
 class TestStixToRelevance(unittest.TestCase, object):
@@ -19,8 +18,7 @@ class TestStixToRelevance(unittest.TestCase, object):
         # queries = '( "process", name of it | "n/a", process id of it as string | "n/a", "sha256", sha256 of image file of it | "n/a", "sha1", sha1 of image file of it | "n/a", "md5", md5 of image file of it | "n/a", pathname of image file of it | "n/a", (start time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of processes whose (name of it as lowercase = "node" as lowercase AND sha256 of image file of it as lowercase = "0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5" as lowercase )'
 
         queries = '<BESAPI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BESAPI.xsd"><ClientQuery><ApplicabilityRelevance>true</ApplicabilityRelevance><QueryText>( "process", name of it | "n/a", process id of it as string | "n/a", "sha256", sha256 of image file of it | "n/a", "sha1", sha1 of image file of it | "n/a", "md5", md5 of image file of it | "n/a", pathname of image file of it | "n/a", (start time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of processes whose (name of it as lowercase = "node" as lowercase AND sha256 of image file of it as lowercase = "0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5" as lowercase )</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
-        parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': '0c0017201b82e1d8613513dc80d1bf46320a957c393b6ca4fb7fa5c3b682c7e5'}, {'attribute': 'process:name', 'comparison_operator': '=', 'value': 'node'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_file_query(self):
 
@@ -30,6 +28,4 @@ class TestStixToRelevance(unittest.TestCase, object):
         # queries = '("file", name of it | "n/a", "sha256", sha256 of it | "n/a", "sha1", sha1 of it | "n/a", "md5", md5 of it | "n/a", pathname of it | "n/a", (modification time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of files whose (name of it as lowercase = "a" as lowercase OR sha256 of it as lowercase = "2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d" as lowercase) of folder ("/root")'
 
         queries = '<BESAPI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="BESAPI.xsd"><ClientQuery><ApplicabilityRelevance>true</ApplicabilityRelevance><QueryText>("file", name of it | "n/a", "sha256", sha256 of it | "n/a", "sha1", sha1 of it | "n/a", "md5", md5 of it | "n/a", pathname of it | "n/a", (modification time of it - "01 Jan 1970 00:00:00 +0000" as time)/second ) of files whose (name of it as lowercase = "a" as lowercase OR sha256 of it as lowercase = "2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d" as lowercase) of folder ("/root")</QueryText><Target><CustomRelevance>true</CustomRelevance></Target></ClientQuery></BESAPI>'
-        parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': '2584c4ba8b0d2a52d94023f420b7e356a1b1a3f2291ad5eba06683d58c48570d'},
-                       {'attribute': 'file:parent_directory_ref.path', 'comparison_operator': '=', 'value': '/root'}, {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'a'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)

--- a/tests/csa_stix_to_sql/test_class.py
+++ b/tests/csa_stix_to_sql/test_class.py
@@ -146,7 +146,7 @@ class TestStixToSql(unittest.TestCase, object):
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
-        result = translation.translate('csa', 'query', '{}', stix_pattern)
+        result = translation.translate('csa', 'query', '{}', stix_pattern, {'validate_pattern': 'true'})
         assert False == result['success']
         assert ErrorCode.TRANSLATION_STIX_VALIDATION.value == result['code']
         assert stix_pattern[1:-1] in result['error']

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -31,11 +31,8 @@ default_time = "last {} minutes".format(DEFAULT_TIMERANGE)
 translation = stix_translation.StixTranslation()
 
 
-def _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix):
+def _test_query_assertions(query, selections, from_statement, where_statement):
     assert query['queries'] == [selections + from_statement + where_statement]
-    assert query['parsed_stix'] == parsed_stix
-    assert query['start_time'] == DEFAULT_START_TIME
-    assert query['end_time'] == DEFAULT_END_TIME
 
 
 def _translate_query(stix_pattern):
@@ -49,62 +46,52 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (INCIDR('192.168.122.84/10',sourceip) OR INCIDR('192.168.122.84/10',destinationip) OR INCIDR('192.168.122.84/10',identityip)) OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} {}".format(
             default_limit, default_time)
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84/10'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = '3001:0:0:0:0:0:0:2']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourceip = '3001:0:0:0:0:0:0:2' OR destinationip = '3001:0:0:0:0:0:0:2') {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '3001:0:0:0:0:0:0:2'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE url = 'http://www.testaddress.com' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_query_from_multiple_observation_expressions_joined_by_AND(self):
         stix_pattern = "[url:value = 'www.example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
         query = _translate_query(stix_pattern)
         # Expect the STIX and to convert to an AQL OR.
         where_statement = "WHERE (url = 'www.example.com') OR ((sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')) {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_query_from_multiple_comparison_expressions_joined_by_AND(self):
         stix_pattern = "[(url:value = 'www.example.com' OR url:value = 'www.test.com') AND mac-addr:value = '00-00-5E-00-53-00']"
         query = _translate_query(stix_pattern)
         # Expect the STIX and to convert to an AQL AND.
         where_statement = "WHERE (sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00') AND (url = 'www.test.com' OR url = 'www.example.com') {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.test.com'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_file_query(self):
         # TODO: Add support for file hashes. Unsure at this point how QRadar queries them
         stix_pattern = "[file:name = 'some_file.exe']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE filename = 'some_file.exe' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE destinationport = '23456' OR sourceport = '12345' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_unmapped_attribute_with_AND(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever' AND file:name = 'some_file.exe']"
@@ -124,39 +111,25 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever' OR file:name = 'some_file.exe']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE filename = 'some_file.exe' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'},
-                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_pattern_with_two_observation_exps_one_with_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever'] OR [file:name = 'some_file.exe' AND url:value = 'www.example.com']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE url = 'www.example.com' AND filename = 'some_file.exe' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-                       {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        for parsing in parsed_stix:
-            assert parsing in query['parsed_stix']
         assert query['queries'] == [selections + from_statement + where_statement]
 
     def test_pattern_with_three_observation_exps_one_with_unmapped_attribute(self):
         stix_pattern = "[file:name = 'some_file.exe' AND network-traffic:some_invalid_attribute = 'whatever'] OR [url:value = 'www.example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (url = 'www.example.com') OR ((sourcemac = '00-00-5E-00-53-00' OR destinationmac = '00-00-5E-00-53-00')) {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-                       {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'},
-                       {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        for parsing in parsed_stix:
-            assert parsing in query['parsed_stix']
         assert query['queries'] == [selections + from_statement + where_statement]
 
     def test_user_account_query(self):
         stix_pattern = "[user-account:user_id = 'root']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE username = 'root' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
@@ -173,15 +146,13 @@ class TestStixToAql(unittest.TestCase, object):
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
             query = _translate_query(stix_pattern)
         where_statement = "WHERE protocolid = '{}' {} {}".format(value, default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' OR network-traffic:end = '2018-06-14T08:36:24.567Z']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE endtime = '1528965384567' OR starttime = '1528965384000' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.567Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_start_stop_qualifiers_with_one_observation(self):
         start_time_01 = "t'2016-06-01T01:30:00.123Z'"
@@ -191,38 +162,31 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root' OR network-traffic:some_invalid_attribute = 'whatever'] START {} STOP {}".format(start_time_01, stop_time_01)
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (username = 'root' AND sourceport = '37020') {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
         assert len(query['queries']) == 1
         assert query['queries'] == [selections + from_statement + where_statement]
-        for parsing in parsed_stix:
-            assert parsing in query['parsed_stix']
-        assert query['start_time'] == unix_start_time_01
-        assert query['end_time'] == unix_stop_time_01
 
-    def test_start_stop_qualifiers_with_two_observations(self):
-        start_time_01 = "t'2016-06-01T01:30:00.123Z'"
-        stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
-        start_time_02 = "t'2016-06-01T03:55:00.123Z'"
-        stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
-        unix_start_time_01 = 1464744600123
-        unix_stop_time_01 = 1464747600123
-        unix_start_time_02 = 1464753300123
-        unix_stop_time_02 = 1464755424743
-        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
-        query = _translate_query(stix_pattern)
-        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
-        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        assert len(query['queries']) == 2
-        assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
-        assert query['parsed_stix'] == parsed_stix
-        # The biggest time window should be returned
-        assert query['start_time'] == unix_start_time_01
-        assert query['end_time'] == unix_stop_time_02
+    # def test_start_stop_qualifiers_with_two_observations(self):
+    #     start_time_01 = "t'2016-06-01T01:30:00.123Z'"
+    #     stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
+    #     start_time_02 = "t'2016-06-01T03:55:00.123Z'"
+    #     stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
+    #     unix_start_time_01 = 1464744600123
+    #     unix_stop_time_01 = 1464747600123
+    #     unix_start_time_02 = 1464753300123
+    #     unix_stop_time_02 = 1464755424743
+    #     stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
+    #     query = _translate_query(stix_pattern)
+    #     where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+    #     where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
+    #     parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
+    #                    {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
+    #                    {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+    #     assert len(query['queries']) == 2
+    #     assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
+    #     assert query['parsed_stix'] == parsed_stix
+    #     # The biggest time window should be returned
+    #     assert query['start_time'] == unix_start_time_01
+    #     assert query['end_time'] == unix_stop_time_02
 
     def test_start_stop_qualifiers_with_three_observations(self):
         start_time_01 = "t'2016-06-01T00:00:00.123Z'"
@@ -239,18 +203,8 @@ class TestStixToAql(unittest.TestCase, object):
         where_statement_01 = "WHERE destinationport = '635' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
         where_statement_02 = "WHERE (sourceip = '333.333.333.0' OR destinationip = '333.333.333.0' OR identityip = '333.333.333.0') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
         where_statement_03 = "WHERE url = 'www.example.com' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'},
-                       {'attribute': 'network-traffic:some_invalid_attribute', 'comparison_operator': '=', 'value': 'whatever'}]
         assert len(query['queries']) == 3
         assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02, selections + from_statement + where_statement_03]
-        for parsing in parsed_stix:
-            assert parsing in query['parsed_stix']
-        # The biggest time window should be returned
-        assert query['start_time'] == unix_start_time_01
-        assert query['end_time'] == unix_stop_time_02
 
     def test_start_stop_qualifiers_with_missing_or_partial_milliseconds(self):
         # missing milliseconds
@@ -268,57 +222,45 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement_01 = "WHERE username = 'root' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
         where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
         assert len(query['queries']) == 2
         assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
-        assert query['parsed_stix'] == parsed_stix
-        # The biggest time window should be returned
-        assert query['start_time'] == unix_start_time_01
-        assert query['end_time'] == unix_stop_time_02
 
     def test_set_operators(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (INCIDR('198.51.100.0/24',sourceip) OR INCIDR('198.51.100.0/24',destinationip) OR INCIDR('198.51.100.0/24',identityip)) {} {}".format(default_limit, default_time)
-        parsed_stix = [{'value': '198.51.100.0/24', 'comparison_operator': 'ISSUBSET', 'attribute': 'ipv4-addr:value'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     # def test_custom_time_limit_and_result_count_and_mappings(self):
     #     stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
     #     custom_options = copy.deepcopy(OPTIONS)
     #     query = translation.translate('qradar', 'query', '{}', stix_pattern, custom_options)
     #     where_statement = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') limit {} last {} minutes".format(custom_options['result_limit'], custom_options['timerange'])
-    #     parsed_stix = [{'value': '192.168.122.83', 'comparison_operator': '=', 'attribute': 'ipv4-addr:value'}]
-    #     assert query == {'queries': [custom_selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+    #     assert query == {'queries': [custom_selections + from_statement + where_statement]}
 
     def test_domainname_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE domainname LIKE '%example.com%' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_generic_filehash_query(self):
         stix_pattern = "[file:hashes.'SHA-256' = 'sha256hash']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE filehash = 'sha256hash' {} {}".format(default_limit, default_time)
-        parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': 'sha256hash'}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     # def test_sha256_filehash_query(self):
     #     stix_pattern = "[file:hashes.'SHA-256' = 'sha256hash']"
     #     query = translation.translate('qradar', 'query', '{}', stix_pattern, OPTIONS)
     #     where_statement = "WHERE (sha256hash = 'sha256hash' OR filehash = 'sha256hash') limit {} last {} minutes".format(OPTIONS['result_limit'], OPTIONS['timerange'])
-    #     parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': 'sha256hash'}]
-    #     assert query == {'queries': [custom_selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+    #     assert query == {'queries': [custom_selections + from_statement + where_statement]}
 
     # def test_multi_filehash_query(self):
     #     stix_pattern = "[file:hashes.'SHA-256' = 'sha256hash'] OR [file:hashes.'MD5' = 'md5hash']"
     #     query = translation.translate('qradar', 'query', '{}', stix_pattern, OPTIONS)
     #     where_statement = "WHERE ((sha256hash = 'sha256hash' OR filehash = 'sha256hash')) OR ((md5hash = 'md5hash' OR filehash = 'md5hash')) limit {} last {} minutes".format(OPTIONS['result_limit'], OPTIONS['timerange'])
-    #     parsed_stix = [{'attribute': 'file:hashes.SHA-256', 'comparison_operator': '=', 'value': 'sha256hash'}, {'attribute': 'file:hashes.MD5', 'comparison_operator': '=', 'value': 'md5hash'}]
-    #     assert query == {'queries': [custom_selections + from_statement + where_statement], 'parsed_stix': parsed_stix}
+    #     assert query == {'queries': [custom_selections + from_statement + where_statement]}
 
     def test_source_and_destination_references(self):
         where_statements = [
@@ -340,22 +282,12 @@ class TestStixToAql(unittest.TestCase, object):
                 stix_pattern = "[{} = {}]".format(reference, datum)
                 query = _translate_query(stix_pattern)
                 where_statement = where_statements[ref_index][dat_index]
-                parsed_stix = [{'attribute': reference, 'comparison_operator': '=', 'value': datum.strip("'")}]
-                _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+                _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_nested_parenthesis_in_pattern(self):
         stix_pattern = "[(ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '100.100.122.90') AND network-traffic:src_port = 37020] OR [user-account:user_id = 'root'] AND [url:value = 'www.example.com']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE (sourceport = '37020' AND ((sourceip = '100.100.122.90' OR destinationip = '100.100.122.90' OR identityip = '100.100.122.90') OR (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83'))) OR ((username = 'root') OR (url = 'www.example.com')) {} {}".format(default_limit, default_time)
-        parsed_stix = [
-            {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-            {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '100.100.122.90'},
-            {'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-            {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-            {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}
-        ]
-        for parsing in parsed_stix:
-            assert parsing in query['parsed_stix']
         assert query['queries'] == [selections + from_statement + where_statement]
 
     def test_LIKE_operator(self):
@@ -363,24 +295,21 @@ class TestStixToAql(unittest.TestCase, object):
         stix_pattern = "[url:value LIKE '{}']".format(search_string)
         query = _translate_query(stix_pattern)
         where_statement = "WHERE url LIKE '%{}%' {} {}".format(search_string, default_limit, default_time)
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': 'LIKE', 'value': search_string}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_payload_string_matching_with_LIKE(self):
         search_string = 'search term'
         stix_pattern = "[x-readable-payload:value LIKE '{}']".format(search_string)
         query = _translate_query(stix_pattern)
         where_statement = "WHERE TEXT SEARCH '{}' {} {}".format(search_string, default_limit, default_time)
-        parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'LIKE', 'value': search_string}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_payload_string_matching_with_MATCH(self):
         search_string = '^.*https://wally.fireeye.com.*$'
         stix_pattern = "[x-readable-payload:value MATCHES '{}']".format(search_string)
         query = _translate_query(stix_pattern)
         where_statement = "WHERE utf8_payload MATCHES '{}' {} {}".format(search_string, default_limit, default_time)
-        parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'MATCHES', 'value': search_string}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_backslash_escaping(self):
         # Stix pattern requires backslash to be double escaped to pass pattern validation.
@@ -391,5 +320,4 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         translated_value = '^.*http://graphics8\\.nytimes\\.com/bcvideo.*$'
         where_statement = "WHERE utf8_payload MATCHES '{}' {} {}".format(translated_value, default_limit, default_time)
-        parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': 'MATCHES', 'value': translated_value}]
-        _test_query_assertions(query, selections, from_statement, where_statement, parsed_stix)
+        _test_query_assertions(query, selections, from_statement, where_statement)

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -133,7 +133,7 @@ class TestStixToAql(unittest.TestCase, object):
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
-        result = translation.translate('qradar', 'query', '{}', stix_pattern)
+        result = translation.translate('qradar', 'query', '{}', stix_pattern, {'validate_pattern': 'true'})
         assert result['success'] == False
         assert ErrorCode.TRANSLATION_STIX_VALIDATION.value == result['code']
         assert stix_pattern[1:-1] in result['error']

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -165,28 +165,21 @@ class TestStixToAql(unittest.TestCase, object):
         assert len(query['queries']) == 1
         assert query['queries'] == [selections + from_statement + where_statement]
 
-    # def test_start_stop_qualifiers_with_two_observations(self):
-    #     start_time_01 = "t'2016-06-01T01:30:00.123Z'"
-    #     stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
-    #     start_time_02 = "t'2016-06-01T03:55:00.123Z'"
-    #     stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
-    #     unix_start_time_01 = 1464744600123
-    #     unix_stop_time_01 = 1464747600123
-    #     unix_start_time_02 = 1464753300123
-    #     unix_stop_time_02 = 1464755424743
-    #     stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
-    #     query = _translate_query(stix_pattern)
-    #     where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
-    #     where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
-    #     parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-    #                    {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-    #                    {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-    #     assert len(query['queries']) == 2
-    #     assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
-    #     assert query['parsed_stix'] == parsed_stix
-    #     # The biggest time window should be returned
-    #     assert query['start_time'] == unix_start_time_01
-    #     assert query['end_time'] == unix_stop_time_02
+    def test_start_stop_qualifiers_with_two_observations(self):
+        start_time_01 = "t'2016-06-01T01:30:00.123Z'"
+        stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
+        start_time_02 = "t'2016-06-01T03:55:00.123Z'"
+        stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
+        unix_start_time_01 = 1464744600123
+        unix_stop_time_01 = 1464747600123
+        unix_start_time_02 = 1464753300123
+        unix_stop_time_02 = 1464755424743
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
+        query = _translate_query(stix_pattern)
+        where_statement_01 = "WHERE username = 'root' AND sourceport = '37020' {} START {} STOP {}".format(default_limit, unix_start_time_01, unix_stop_time_01)
+        where_statement_02 = "WHERE (sourceip = '192.168.122.83' OR destinationip = '192.168.122.83' OR identityip = '192.168.122.83') {} START {} STOP {}".format(default_limit, unix_start_time_02, unix_stop_time_02)
+        assert len(query['queries']) == 2
+        assert query['queries'] == [selections + from_statement + where_statement_01, selections + from_statement + where_statement_02]
 
     def test_start_stop_qualifiers_with_three_observations(self):
         start_time_01 = "t'2016-06-01T00:00:00.123Z'"

--- a/tests/stix_translation/test_carbonblack_stix_to_cb.py
+++ b/tests/stix_translation/test_carbonblack_stix_to_cb.py
@@ -11,9 +11,8 @@ module = "carbonblack"
 def to_json(queries):
     return list(map(lambda x: json.dumps(x), queries))
 
-def _test_query_assertions(query, queries, parsed_stix):
+def _test_query_assertions(query, queries):
     assert query['queries'] == queries
-    assert query['parsed_stix'] == parsed_stix
 
 
 class TestStixToCB(unittest.TestCase, object):
@@ -22,50 +21,43 @@ class TestStixToCB(unittest.TestCase, object):
         stix_pattern = "[file:name = 'some_file.exe']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "observed_filename:some_file.exe", "dialect": "binary"}])
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_file_and_domain_query(self):
         stix_pattern = "[file:name = 'some_file.exe' AND domain-name:value = 'example.com']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "observed_filename:some_file.exe and domain:example.com", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_ipv4_query(self):
         stix_pattern = "[ipv4-addr:value = '10.0.0.1']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "ipaddr:10.0.0.1", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '10.0.0.1'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_hash_query(self):
         stix_pattern = "[file:hashes.MD5 = '5746bd7e255dd6a8afa06f7c42c1ba41']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "md5:5746bd7e255dd6a8afa06f7c42c1ba41", "dialect": "binary"}])
-        parsed_stix = [{'attribute': 'file:hashes.MD5', 'comparison_operator': '=', 'value': '5746bd7e255dd6a8afa06f7c42c1ba41'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_command_line_query(self):
         stix_pattern = "[process:command_line = 'cmd.exe']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "cmdline:cmd.exe", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'process:command_line', 'comparison_operator': '=', 'value': 'cmd.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_simple_or_query(self):
         stix_pattern = "[ipv4-addr:value = '10.0.0.1' OR ipv4-addr:value = '10.0.0.2']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "ipaddr:10.0.0.1 or ipaddr:10.0.0.2", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '10.0.0.2'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '10.0.0.1'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_simple_and_query(self):
         stix_pattern = "[process:name = 'cmd.exe' AND process:creator_user_ref.user_id != 'SYSTEM']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
         queries = to_json([{"query": "process_name:cmd.exe and -(username:SYSTEM)", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'process:creator_user_ref.user_id', 'comparison_operator': '!=', 'value': 'SYSTEM'}, {'attribute': 'process:name', 'comparison_operator': '=', 'value': 'cmd.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_custom_mapping(self):
         custom_mappings = {"binary":{}, "process":
@@ -82,8 +74,7 @@ class TestStixToCB(unittest.TestCase, object):
         stix_pattern = "[file:custom_name = 'some_file.exe']"
         query = translation.translate(module, 'query', '{}', stix_pattern, custom_options)
         queries = to_json([{"query": "observed_filename:some_file.exe", "dialect": "process"}])
-        parsed_stix = [{'attribute': 'file:custom_name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_query_map_coverage(self):
         stix_to_cb_mapping = {
@@ -149,14 +140,8 @@ class TestStixToCB(unittest.TestCase, object):
     def test_nested_parenthesis_in_pattern(self):
         stix_pattern = "[(ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '100.100.122.90') AND network-traffic:src_port = 37020 OR user-account:user_id = 'root']"
         query = translation.translate(module, 'query', '{}', stix_pattern)
-        parsed_stix = [
-            {'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-            {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-            {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '100.100.122.90'},
-            {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'},
-        ]
         queries = to_json([{"query": "((ipaddr:192.168.122.83 or ipaddr:100.100.122.90) and ipport:37020) or username:root", "dialect": "process"}])
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_start_stop_merged(self):
         stix_to_cb_mapping = {

--- a/tests/stix_translation/test_elastic_ecs_stix_to_query.py
+++ b/tests/stix_translation/test_elastic_ecs_stix_to_query.py
@@ -181,7 +181,7 @@ class TestStixtoQuery(unittest.TestCase, object):
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
-        result = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
+        result = translation.translate('elastic_ecs', 'query', '{}', stix_pattern, {'validate_pattern': 'true'})
         assert result['success'] == False
         assert ErrorCode.TRANSLATION_STIX_VALIDATION.value == result['code']
         assert stix_pattern[1:-1] in result['error']

--- a/tests/stix_translation/test_elastic_ecs_stix_to_query.py
+++ b/tests/stix_translation/test_elastic_ecs_stix_to_query.py
@@ -12,9 +12,10 @@ DEFAULT_TIMERANGE = 5
 
 translation = stix_translation.StixTranslation()
 
-def _test_query_assertions(translated_query, test_query, parsed_stix):
+
+def _test_query_assertions(translated_query, test_query):
     assert translated_query['queries'] == test_query
-    assert translated_query['parsed_stix'] == parsed_stix
+
 
 def _start_and_stop_time():
     stop_time = datetime.datetime.utcnow()
@@ -25,6 +26,7 @@ def _start_and_stop_time():
     converted_starttime = start_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     converted_stoptime = stop_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     return converted_starttime, converted_stoptime
+
 
 def _remove_timestamp_from_query(queries):
     pattern = r'\s*AND\s*\(\@timestamp:\["\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z"\s*TO\s*"\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z"\]\)'
@@ -41,64 +43,55 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.ip : "192.168.122.84" OR destination.ip : "192.168.122.84" OR client.ip : "192.168.122.84" OR server.ip : "192.168.122.84") OR (source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83")']
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = '3001:0:0:0:0:0:0:2']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.ip : "3001:0:0:0:0:0:0:2" OR destination.ip : "3001:0:0:0:0:0:0:2" OR client.ip : "3001:0:0:0:0:0:0:2" OR server.ip : "3001:0:0:0:0:0:0:2")']
-        parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': '3001:0:0:0:0:0:0:2'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['url.original : "http://www.testaddress.com"']
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.mac : "00-00-5E-00-53-00" OR destination.mac : "00-00-5E-00-53-00" OR client.mac : "00-00-5E-00-53-00" OR server.mac : "00-00-5E-00-53-00")']
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_query_from_multiple_observation_expressions_joined_by_AND(self):
         stix_pattern = "[url:value = 'www.example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(url.original : "www.example.com") OR ((source.mac : "00-00-5E-00-53-00" OR destination.mac : "00-00-5E-00-53-00" OR client.mac : "00-00-5E-00-53-00" OR server.mac : "00-00-5E-00-53-00"))']
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_query_from_multiple_comparison_expressions_joined_by_AND(self):
         stix_pattern = "[(url:value = 'www.example.com' OR url:value = 'www.test.com') AND mac-addr:value = '00-00-5E-00-53-00']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.mac : "00-00-5E-00-53-00" OR destination.mac : "00-00-5E-00-53-00" OR client.mac : "00-00-5E-00-53-00" OR server.mac : "00-00-5E-00-53-00") AND (url.original : "www.test.com" OR url.original : "www.example.com")']
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.test.com'},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_file_query(self):
         stix_pattern = "[file:name = 'some_file.exe']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['process.name : "some_file.exe"']
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_complex_query(self):
         stix_pattern = "[network-traffic:protocols[*] LIKE 'ipv_' AND network-traffic:src_port>443] START t'2019-04-11T08:42:39.297Z' STOP t'2019-04-11T08:43:39.297Z' OR [user-account:user_id = '_' AND artifact:payload_bin LIKE '%'] START t'2019-04-11T14:35:44.011Z' STOP t'2019-04-21T16:35:44.011Z' AND [process:pid<700 OR url:value LIKE '%' AND process:creator_user_ref.user_id IN ('root','admin')] START t'2019-04-11T14:35:44.011Z' STOP t'2019-04-17T14:35:44.011Z'"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
-        test_query = ['(source.port:>443 OR client.port:>443) AND (network.transport : ipv? OR network.type : ipv? OR network.protocol : ipv?) AND (@timestamp:["2019-04-11T08:42:39.297Z" TO "2019-04-11T08:43:39.297Z"])', 'event.original : * AND user.name : "_" AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-21T16:35:44.011Z"])', '(user.name : ("root" OR "admin") AND url.original : *) OR process.pid:<700 AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-17T14:35:44.011Z"])']
+        test_query = ['(source.port:>443 OR client.port:>443) AND (network.transport : ipv? OR network.type : ipv? OR network.protocol : ipv?) AND (@timestamp:["2019-04-11T08:42:39.297Z" TO "2019-04-11T08:43:39.297Z"])',
+                      'event.original : * AND user.name : "_" AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-21T16:35:44.011Z"])', '(user.name : ("root" OR "admin") AND url.original : *) OR process.pid:<700 AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-17T14:35:44.011Z"])']
         assert translated_query['queries'] == test_query
 
     def test_data_mapping_exception(self):
@@ -114,56 +107,49 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(NOT process.name : "some_file.exe" AND process.name:*)']
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '!=', 'value': 'some_file.exe'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(destination.port : "23456" OR server.port : "23456") OR (source.port : "12345" OR client.port : "12345")']
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_lessthan_greaterthan(self):
         stix_pattern = "[network-traffic:src_port > 12345 AND network-traffic:dst_port < 23456]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(destination.port:<23456 OR server.port:<23456) AND (source.port:>12345 OR client.port:>12345)']
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '<', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '>', 'value': 12345}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_src_ref_equal(self):
         stix_pattern = "[network-traffic:src_ref.value = '127.0.0.1']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.ip : "127.0.0.1" OR client.ip : "127.0.0.1")']
-        parsed_stix = [{'attribute': 'network-traffic:src_ref.value', 'comparison_operator': '=', 'value': '127.0.0.1'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_src_ref_notequal(self):
         stix_pattern = "[network-traffic:src_ref.value != '127.0.0.1']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['((NOT source.ip : "127.0.0.1" AND source.ip:*) OR (NOT client.ip : "127.0.0.1" AND client.ip:*))']
-        parsed_stix = [{'attribute': 'network-traffic:src_ref.value', 'comparison_operator': '!=', 'value': '127.0.0.1'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_greaterthanorequal(self):
         stix_pattern = "[network-traffic:src_port >=443]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.port:>=443 OR client.port:>=443)']
-        parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '>=', 'value': 443}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_lessthanorequal(self):
         stix_pattern = "[network-traffic:src_port <=443]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(source.port:<=443 OR client.port:<=443)']
-        parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '<=', 'value': 443}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_network_traffic_in_operator(self):
         stix_pattern = "[network-traffic:protocols[*] IN ('tcp','dns')]"
@@ -177,8 +163,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(network.transport : ?n* OR network.type : ?n* OR network.protocol : ?n*) OR (source.port : "12345" OR client.port : "12345")']
-        parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': 'LIKE', 'value': '_n%'}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
@@ -192,8 +177,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['user.name : "root"']
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
@@ -207,40 +191,35 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(process.start:["2019-04-10T11:34:06.000Z" TO *])']
-        parsed_stix = [{'attribute': 'process:created', 'comparison_operator': '>', 'value': '2019-04-10T11:34:05.500Z'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_process_created_lessthan(self):
         stix_pattern = "[process:created<'2019-04-10T11:34:05.500Z']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(process.start:[* TO "2019-04-10T11:34:04.000Z"])']
-        parsed_stix = [{'attribute': 'process:created', 'comparison_operator': '<', 'value': '2019-04-10T11:34:05.500Z'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_process_created_greaterthan_orequal(self):
         stix_pattern = "[process:created>='2019-04-10T11:34:05.500Z']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(process.start:["2019-04-10T11:34:05.500Z" TO *])']
-        parsed_stix = [{'attribute': 'process:created', 'comparison_operator': '>=', 'value': '2019-04-10T11:34:05.500Z'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_process_created_lessthan_orequal(self):
         stix_pattern = "[process:created<='2019-04-10T11:34:05.500Z']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['(process.start:[* TO "2019-04-10T11:34:05.500Z"])']
-        parsed_stix = [{'attribute': 'process:created', 'comparison_operator': '<=', 'value': '2019-04-10T11:34:05.500Z'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_process_created_equal(self):
         stix_pattern = "[process:created='2019-04-10T11:34:05.500Z']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['process.start : "2019-04-10T11:34:05.500Z"']
-        parsed_stix = [{'attribute': 'process:created', 'comparison_operator': '=', 'value': '2019-04-10T11:34:05.500Z'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_combined_observations_with_one_qualifier(self):
         start_time = "t'2019-04-01T01:30:00.123Z'"
@@ -248,12 +227,10 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "([network-traffic:src_port = 37020 AND user-account:user_id = 'root'] OR [ipv4-addr:value = '192.168.122.83']) START {} STOP {}".format(start_time, stop_time)
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'][-1] = _remove_timestamp_from_query(translated_query['queries'][-1])
-        test_query = ['(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])', 'user.name : "root" AND (source.port : "37020" OR client.port : "37020")']
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        test_query = ['(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])',
+                      'user.name : "root" AND (source.port : "37020" OR client.port : "37020")']
         assert len(translated_query['queries']) == 2
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_start_stop_qualifiers_with_two_observations(self):
         start_time_01 = "t'2019-04-01T01:30:00.123Z'"
@@ -262,12 +239,10 @@ class TestStixtoQuery(unittest.TestCase, object):
         stop_time_02 = "t'2019-04-01T04:30:24.743Z'"
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
-        test_query = ['user.name : "root" AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])', '(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83") AND (@timestamp:["2019-04-01T03:55:00.123Z" TO "2019-04-01T04:30:24.743Z"])']
-        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        test_query = ['user.name : "root" AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])',
+                      '(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83") AND (@timestamp:["2019-04-01T03:55:00.123Z" TO "2019-04-01T04:30:24.743Z"])']
         assert len(translated_query['queries']) == 2
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_start_stop_qualifiers_with_three_observations(self):
         start_time_01 = "t'2019-04-01T00:00:00.123Z'"
@@ -278,18 +253,14 @@ class TestStixtoQuery(unittest.TestCase, object):
             start_time_01, stop_time_01, start_time_02, stop_time_02)
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'][-1] = _remove_timestamp_from_query(translated_query['queries'][-1])
-        test_query = ['(destination.port : "635" OR server.port : "635") AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T00:00:00.123Z" TO "2019-04-01T01:11:11.456Z"])', '(source.ip : "333.333.333.0" OR destination.ip : "333.333.333.0" OR client.ip : "333.333.333.0" OR server.ip : "333.333.333.0") AND (@timestamp:["2019-04-07T02:22:22.789Z" TO "2019-04-07T03:33:33.012Z"])', 'url.original : "www.example.com"']
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 635},
-                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
-                       {'attribute': 'url:value', 'comparison_operator': '=', 'value': 'www.example.com'},
-                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '333.333.333.0'}]
+        test_query = ['(destination.port : "635" OR server.port : "635") AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T00:00:00.123Z" TO "2019-04-01T01:11:11.456Z"])',
+                      '(source.ip : "333.333.333.0" OR destination.ip : "333.333.333.0" OR client.ip : "333.333.333.0" OR server.ip : "333.333.333.0") AND (@timestamp:["2019-04-07T02:22:22.789Z" TO "2019-04-07T03:33:33.012Z"])', 'url.original : "www.example.com"']
         assert len(translated_query['queries']) == 3
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)
 
     def test_match_operator(self):
         stix_pattern = "[artifact:payload_bin MATCHES '1*']"  # Elastic search does not support PCRE
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
         test_query = ['event.original : 1*']
-        parsed_stix = [{'attribute': 'artifact:payload_bin', 'comparison_operator': 'MATCHES', 'value': '1*'}]
-        _test_query_assertions(translated_query, test_query, parsed_stix)
+        _test_query_assertions(translated_query, test_query)

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -102,7 +102,7 @@ class TestStixToSpl(unittest.TestCase, object):
 
     def test_invalid_stix_pattern(self):
         stix_pattern = "[not_a_valid_pattern]"
-        result = translation.translate('splunk', 'query', '{}', stix_pattern)
+        result = translation.translate('splunk', 'query', '{}', stix_pattern, {'validate_pattern': 'true'})
         assert False == result['success']
         assert ErrorCode.TRANSLATION_STIX_VALIDATION.value == result['code']
         assert stix_pattern[1:-1] in result['error']

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -31,9 +31,8 @@ default_timerange_spl = '-' + str(DEFAULT_TIMERANGE) + 'minutes'
 translation = stix_translation.StixTranslation()
 
 
-def _test_query_assertions(query, queries, parsed_stix):
+def _test_query_assertions(query, queries):
     assert query['queries'] == queries
-    assert query['parsed_stix'] == parsed_stix
 
 
 class TestStixToSpl(unittest.TestCase, object):
@@ -42,66 +41,57 @@ class TestStixToSpl(unittest.TestCase, object):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '192.168.122.84']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (((src_ip = "192.168.122.84") OR (dest_ip = "192.168.122.84")) OR ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_ipv6_query(self):
         stix_pattern = "[ipv6-addr:value = 'fe80::8c3b:a720:dc5c:2abf%19']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_ipv6 = "fe80::8c3b:a720:dc5c:2abf%19") OR (dest_ipv6 = "fe80::8c3b:a720:dc5c:2abf%19")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'ipv6-addr:value', 'comparison_operator': '=', 'value': 'fe80::8c3b:a720:dc5c:2abf%19'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_url_query(self):
         stix_pattern = "[url:value = 'http://www.testaddress.com']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
-        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': '=', 'value': 'http://www.testaddress.com'}]
         queries = 'search (url = "http://www.testaddress.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_domain_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (url = "example.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_query_from_multiple_observation_expressions_joined_by_AND(self):
         stix_pattern = "[domain-name:value = 'example.com'] AND [mac-addr:value = '00-00-5E-00-53-00']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         # Expect the STIX AND to convert to an SPL OR.
         queries = 'search (url = "example.com") OR ((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}, {'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_query_from_multiple_comparison_expressions_joined_by_AND(self):
         stix_pattern = "[domain-name:value = 'example.com' AND mac-addr:value = '00-00-5E-00-53-00']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         # Expect the STIX AND to convert to an AQL AND.
         queries = 'search (((src_mac = "00-00-5E-00-53-00") OR (dest_mac = "00-00-5E-00-53-00")) AND (url = "example.com")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'domain-name:value', 'comparison_operator': '=', 'value': 'example.com'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_file_query(self):
         stix_pattern = "[file:name = 'some_file.exe']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (file_name = "some_file.exe") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'file:name', 'comparison_operator': '=', 'value': 'some_file.exe'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((dest_port = 23456) OR (src_port = 12345)) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'network-traffic:dst_port', 'comparison_operator': '=', 'value': 23456}, {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 12345}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_unmapped_attribute(self):
         stix_pattern = "[network-traffic:some_invalid_attribute = 'whatever']"
@@ -125,36 +115,31 @@ class TestStixToSpl(unittest.TestCase, object):
             stix_pattern = "[network-traffic:protocols[*] = '" + key + "']"
             query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (protocol = "'+key+'") earliest="{}" | head {} | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'.format(default_timerange_spl, DEFAULT_LIMIT)
-        parsed_stix = [{'attribute': 'network-traffic:protocols[*]', 'comparison_operator': '=', 'value': key}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_network_traffic_start_stop(self):
         stix_pattern = "[network-traffic:'start' = '2018-06-14T08:36:24.000Z' OR network-traffic:end = '2018-06-14T08:36:24.000Z']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((latest = "2018-06-14T08:36:24.000Z") OR (earliest = "2018-06-14T08:36:24.000Z")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'network-traffic:end', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}, {'attribute': 'network-traffic:start', 'comparison_operator': '=', 'value': '2018-06-14T08:36:24.000Z'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_start_stop_qualifiers(self):
         stix_pattern = "[network-traffic:src_port = 37020] START t'2016-06-01T01:30:00.000Z' STOP t'2016-06-01T02:20:00.000Z' OR [ipv4-addr:value = '192.168.122.83'] START t'2016-06-01T03:55:00.000Z' STOP t'2016-06-01T04:30:00.000Z'"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (src_port = 37020) earliest="06/01/2016:01:30:00" latest="06/01/2016:02:20:00" OR ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83")) earliest="06/01/2016:03:55:00" latest="06/01/2016:04:30:00" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_start_stop_qualifiers_one_time(self):
         stix_pattern = "[network-traffic:src_port = 37020] START t'2016-06-01T01:30:00.000Z' STOP t'2016-06-01T02:20:00.000Z'"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search (src_port = 37020) earliest="06/01/2016:01:30:00" latest="06/01/2016:02:20:00" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_issubset_operator(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
         queries = 'search ((src_ip = "198.51.100.0/24") OR (dest_ip = "198.51.100.0/24")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': 'ISSUBSET', 'value': '198.51.100.0/24'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_custom_time_limit_and_result_count(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
@@ -165,8 +150,7 @@ class TestStixToSpl(unittest.TestCase, object):
 
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83")) earliest="-25minutes" | head 5000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_custom_mapping(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' AND mac-addr:value = '00-00-5E-00-53-00']"
@@ -202,8 +186,7 @@ class TestStixToSpl(unittest.TestCase, object):
 
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search ((mac = "00-00-5E-00-53-00") AND ((src_ip = "192.168.122.83") OR (dest_ip = "192.168.122.83"))) earliest="-15minutes" | head 1000 | fields src_ip, src_port'
-        parsed_stix = [{'attribute': 'mac-addr:value', 'comparison_operator': '=', 'value': '00-00-5E-00-53-00'}, {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)
 
     def test_free_search(self):
         stix_pattern = "[x-readable-payload:value = 'malware']"
@@ -214,5 +197,4 @@ class TestStixToSpl(unittest.TestCase, object):
 
         query = translation.translate('splunk', 'query', '{}', stix_pattern, options)
         queries = 'search _raw=*malware* earliest="-25minutes" | head 5000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
-        parsed_stix = [{'attribute': 'x-readable-payload:value', 'comparison_operator': '=', 'value': 'malware'}]
-        _test_query_assertions(query, queries, parsed_stix)
+        _test_query_assertions(query, queries)

--- a/tests/stix_translation/test_stix_parsing.py
+++ b/tests/stix_translation/test_stix_parsing.py
@@ -1,0 +1,63 @@
+from stix_shifter.stix_translation import stix_translation
+from stix_shifter.stix_translation.src.modules.qradar import qradar_data_mapping
+from stix_shifter.utils.error_response import ErrorCode
+import unittest
+import random
+import json
+import copy
+from freezegun import freeze_time
+
+options_file = open('tests/stix_translation/qradar_stix_to_aql/options.json').read()
+selections_file = open('stix_shifter/stix_translation/src/modules/qradar/json/aql_event_fields.json').read()
+protocols_file = open('stix_shifter/stix_translation/src/modules/qradar/json/network_protocol_map.json').read()
+OPTIONS = json.loads(options_file)
+DEFAULT_SELECTIONS = json.loads(selections_file)
+DEFAULT_LIMIT = 10000
+DEFAULT_TIMERANGE = 5
+DEFAULT_START_TIME = 1548926700000
+DEFAULT_END_TIME = 1548927000000
+PROTOCOLS = json.loads(protocols_file)
+
+
+freeze_time("2019-01-31 09:30:00").start()
+selections = "SELECT {}".format(", ".join(DEFAULT_SELECTIONS['default']))
+custom_selections = "SELECT {}".format(", ".join(OPTIONS['select_fields']))
+from_statement = " FROM events "
+
+
+default_limit = "limit {}".format(DEFAULT_LIMIT)
+default_time = "last {} minutes".format(DEFAULT_TIMERANGE)
+
+translation = stix_translation.StixTranslation()
+
+
+def _parse_query(stix_pattern):
+    return translation.translate('qradar', 'parse', '{}', stix_pattern)
+
+
+class TestStixParsing(unittest.TestCase, object):
+
+    def test_default_timerange(self):
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '192.168.122.84/10']"
+        parsing = _parse_query(stix_pattern)
+        parsed_stix = [{'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.84/10'},
+                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        assert parsing['parsed_stix'] == parsed_stix
+        # Time window should be last 5 minutes from frozen time
+        assert parsing['start_time'] == 1548926700000
+        assert parsing['end_time'] == 1548927000000
+
+    def test_multiple_start_stop_qualifiers(self):
+        start_time_01 = "t'2016-06-01T01:30:00.123Z'"
+        stop_time_01 = "t'2016-06-01T02:20:00.123Z'"
+        start_time_02 = "t'2016-06-01T03:55:00.123Z'"
+        stop_time_02 = "t'2016-06-01T04:30:24.743Z'"
+        stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
+        parsing = _parse_query(stix_pattern)
+        parsed_stix = [{'attribute': 'user-account:user_id', 'comparison_operator': '=', 'value': 'root'},
+                       {'attribute': 'network-traffic:src_port', 'comparison_operator': '=', 'value': 37020},
+                       {'attribute': 'ipv4-addr:value', 'comparison_operator': '=', 'value': '192.168.122.83'}]
+        assert parsing['parsed_stix'] == parsed_stix
+        # The biggest time window should be returned
+        assert parsing['start_time'] == 1464744600123
+        assert parsing['end_time'] == 1464755424743


### PR DESCRIPTION
Allows the STIX objects, attributes, comparators, values, and time range to be pulled from the pattern in a stix-shifter call separate from the pattern translation flow.

*** The below is required to be filled by any non-IBM employee, in order for their pull request to be accepted ***
DCO 1.1 Signed-off-by: [NAME] <[EMAIL]>
