### PR TITLE
Fix ECS adapter integration with ISC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To learn more about STIX, see the following references:
 
 STIX-shifter is an open source python library allowing software to connect to products that house data repositories by using `STIX Patterning`, and return results as `STIX Observations`.
 
-STIX-Shifter is the heart of the **Universal Data Service** that is provided as part of [IBM Security Connect](https://www.ibm.com/security/connect/).
+STIX-Shifter is the heart of the **Universal Data Service** (UDS) that is provided as part of [IBM Security Connect](https://www.ibm.com/security/connect/) (ISC).
 
 ### What is STIX Patterning? What are STIX Observations?
 
@@ -416,6 +416,16 @@ python main.py transmit qradar '{"host":"<ip address>", "port":"<port>", "cert":
 ```
 python main.py transmit qradar '{"host":"<ip address>", "port":"<port>", "cert":"-----BEGIN CERTIFICATE-----\ncErTificateGoesHere=\n-----END CERTIFICATE-----"}' '{"auth": {"SEC":"1234..sec..uid..5678"}}' is_async
 ```
+
+#### How UDS uses STIX-shifter
+
+IBM's Universal Data Service first uses the translation modules to convert a STIX pattern into one or more native queries; this happens for each data source connected to ISC.
+
+Each translated query is sent to its respective data source, query status is polled, and query results are returned, all via the transmission modules.
+
+The translation modules are again used to convert the JSON results into STIX observed-data objects. These objects get wrapped in STIX bundles to be used by the ISC service.
+
+Throughout this process, all data is stateless. The pattern, translated query, JSON results, and STIX objects do not get stored anywhere. UDS simply submits a pattern and fetches the resulting STIX as needed.
 
 ## Glossary
 

--- a/stix_shifter/stix_transmission/src/modules/async_dummy/api_client.py
+++ b/stix_shifter/stix_transmission/src/modules/async_dummy/api_client.py
@@ -4,6 +4,7 @@ from ..utils.RestApiClient import RestApiClient
 class APIClient():
 
     def __init__(self, connection, configuration):
+         # Uncomment when implementing data source API client.
         # auth = configuration.get('auth')
         # headers = dict()
         # headers['X-Auth-Token'] = auth.get('token')
@@ -13,6 +14,9 @@ class APIClient():
         #                             headers,
         #                             cert_verify=connection.get('cert_verify', 'True')
         #                             )
+
+        # Placeholder client to allow dummy transmission calls.
+        # Remove when implementing data source API client.
         self.client = "data source API client"
 
     def ping_data_source(self):

--- a/stix_shifter/stix_transmission/src/modules/async_dummy/api_client.py
+++ b/stix_shifter/stix_transmission/src/modules/async_dummy/api_client.py
@@ -4,6 +4,15 @@ from ..utils.RestApiClient import RestApiClient
 class APIClient():
 
     def __init__(self, connection, configuration):
+        # auth = configuration.get('auth')
+        # headers = dict()
+        # headers['X-Auth-Token'] = auth.get('token')
+        # self.client = RestApiClient(connection.get('host'),
+        #                             connection.get('port'),
+        #                             connection.get('cert', None),
+        #                             headers,
+        #                             cert_verify=connection.get('cert_verify', 'True')
+        #                             )
         self.client = "data source API client"
 
     def ping_data_source(self):

--- a/stix_shifter/stix_transmission/src/modules/async_dummy/async_dummy_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/async_dummy/async_dummy_connector.py
@@ -1,5 +1,5 @@
 from ..base.base_connector import BaseConnector
-from .apiclient import APIClient
+from .api_client import APIClient
 from ..base.base_status_connector import Status
 from json import loads
 from enum import Enum

--- a/stix_shifter/stix_transmission/src/modules/elastic_ecs/elastic_ecs_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/elastic_ecs/elastic_ecs_connector.py
@@ -12,6 +12,8 @@ class Connector(BaseConnector):
     def __init__(self, connection, configuration):
         self.api_client = APIClient(connection, configuration)
         self.ping_connector = self
+        self.results_connector = self
+        self.status_connector = self
         self.query_connector = self
         self.is_async = False
 
@@ -61,7 +63,7 @@ class Connector(BaseConnector):
                     # and (response_json['hits']['total']['value'] >= 0 or response_json['hits']['total'] >= 0):
                     print("Total # of hits:" + str(response_json['hits']['total']))
                     return_obj['data'] = [record['_source'] for record in response_json["hits"]["hits"]]
-                    print ("Total # of records: " + str(len(return_obj['data'])))
+                    print("Total # of records: " + str(len(return_obj['data'])))
 
             return return_obj
         except Exception as e:

--- a/stix_shifter/stix_transmission/src/modules/elastic_ecs/elastic_ecs_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/elastic_ecs/elastic_ecs_connector.py
@@ -49,6 +49,9 @@ class Connector(BaseConnector):
     def create_query_connection(self, query):
         return {"success": True, "search_id": query}
 
+    def create_status_connection(self, search_id):
+        return {"success": True, "status": "COMPLETED", "progress": 100}
+
     def create_results_connection(self, query, offset, length):
         response_txt = None
         return_obj = dict()

--- a/stix_shifter/stix_transmission/src/modules/synchronous_dummy/api_client.py
+++ b/stix_shifter/stix_transmission/src/modules/synchronous_dummy/api_client.py
@@ -4,6 +4,7 @@ from ..utils.RestApiClient import RestApiClient
 class APIClient():
 
     def __init__(self, connection, configuration):
+        # Uncomment when implementing data source API client.
         # auth = configuration.get('auth')
         # headers = dict()
         # headers['X-Auth-Token'] = auth.get('token')
@@ -12,7 +13,10 @@ class APIClient():
         #                             connection.get('cert', None),
         #                             headers,
         #                             cert_verify=connection.get('cert_verify', 'True')
-        #                             )
+        #
+
+        # Placeholder client to allow dummy transmission calls.
+        # Remove when implementing data source API client.                            )
         self.client = "data source API client"
 
     def ping_box(self):

--- a/stix_shifter/stix_transmission/src/modules/synchronous_dummy/api_client.py
+++ b/stix_shifter/stix_transmission/src/modules/synchronous_dummy/api_client.py
@@ -1,0 +1,27 @@
+from ..utils.RestApiClient import RestApiClient
+
+
+class APIClient():
+
+    def __init__(self, connection, configuration):
+        # auth = configuration.get('auth')
+        # headers = dict()
+        # headers['X-Auth-Token'] = auth.get('token')
+        # self.client = RestApiClient(connection.get('host'),
+        #                             connection.get('port'),
+        #                             connection.get('cert', None),
+        #                             headers,
+        #                             cert_verify=connection.get('cert_verify', 'True')
+        #                             )
+        self.client = "data source API client"
+
+    def ping_box(self):
+        # Pings the data source
+        return {"code": 200, "results": "Was able to hit the data source"}
+
+    def run_search(self, query_expression, offset=None, length=None):
+        # headers = dict()
+        # return self.client.call_api(endpoint, 'GET', headers, urldata=data)
+
+        # Return the search results. Results must be in JSON format before being translated into STIX
+        return {"code": 200, "search_id": query_expression, "results": "Results from search"}

--- a/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
@@ -7,9 +7,10 @@ import time
 class Connector(BaseConnector):
     def __init__(self):
         self.is_async = False
-
-        self.results_connector = self
         self.ping_connector = self
+        self.results_connector = self
+        self.status_connector = self
+        self.query_connector = self
 
     def ping(self):
         return "synchronous ping"

--- a/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
@@ -1,63 +1,63 @@
 from ..base.base_connector import BaseConnector
-# from .synchronous_dummy_results_connector import SynchronousDummyResultsConnector
-# from .synchronous_dummy_ping import SynchronousDummyPing
-import time
+from .....utils.error_response import ErrorResponder
+from .api_client import APIClient
+import json
+
+
+class UnexpectedResponseException(Exception):
+    pass
 
 
 class Connector(BaseConnector):
-    def __init__(self):
+    def __init__(self, connection, configuration):
+        self.api_client = APIClient(connection, configuration)
         self.is_async = False
         self.ping_connector = self
         self.results_connector = self
         self.status_connector = self
         self.query_connector = self
 
-    def ping(self):
-        return "synchronous ping"
+    def _handle_errors(self, response, return_obj):
+        response_code = response['code']
 
+        if 200 <= response_code < 300:
+            return_obj['success'] = True
+            response_json = response
+            if 'results' in response_json:
+                return_obj['data'] = response_json['results']
+        else:
+            raise UnexpectedResponseException
+        return return_obj
+
+    def ping(self):
+        return_obj = {}
+        try:
+            response = self.api_client.ping_box()
+            return self._handle_errors(response, return_obj)
+        except Exception as err:
+            print('error when pinging datasource {}:'.format(err))
+            raise
+
+    # Leave dummy implementation as is for synchronous data sources
     def create_query_connection(self, query):
         return {"success": True, "search_id": query}
 
+    # Leave dummy implementation as is for synchronous data sources
     def create_status_connection(self, search_id):
         return {"success": True, "status": "COMPLETED", "progress": 100}
 
-    def create_results_connection(self, params, options):
-        """
-        Creates a connection to the specified datasource to send a query
+    # Query is sent to data source and results are returned in one step
+    def create_results_connection(self, search_id, offset, length):
+        response_txt = None
+        return_obj = {}
+        try:
+            query = search_id
+            response = self.api_client.run_search(query, offset, length)
+            return self._handle_errors(response, return_obj)
 
-        :param params: the parameters for the query
-        :param options: CLI options passed in
-
-        :return: in dummy connectors, just returns passed in parameters
-        """
-        config = params['config']
-
-        # The post-processed query, already translated from STIX SCO
-        query = params['query']
-
-        # set headers
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json"
-        }
-
-        # construct request object, purely for visual purposes in dummy implementation
-        request = {
-            "host": config['host'],
-            "path": config['path'] + query,
-            "port": config['port'],
-            "headers": headers,
-            "method": "GET"
-        }
-
-        print(request)
-        time.sleep(3)
-
-        dummy_data = {"obj_1": {}, "obj_2": {}, "obj_3": {}, "obj_4": {}, "obj_5": {}}
-
-        return_obj = {
-            "response_code": 200,
-            "query_results": dummy_data
-        }
-
-        return return_obj
+        except Exception as e:
+            if response_txt is not None:
+                ErrorResponder.fill_error(return_obj, message='unexpected exception')
+                print('can not parse response: ' + str(response_txt))
+            else:
+                raise e

--- a/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/synchronous_dummy/synchronous_dummy_connector.py
@@ -15,6 +15,12 @@ class Connector(BaseConnector):
     def ping(self):
         return "synchronous ping"
 
+    def create_query_connection(self, query):
+        return {"success": True, "search_id": query}
+
+    def create_status_connection(self, search_id):
+        return {"success": True, "status": "COMPLETED", "progress": 100}
+
     def create_results_connection(self, params, options):
         """
         Creates a connection to the specified datasource to send a query

--- a/tests/stix_transmission/test_synchronous_dummy.py
+++ b/tests/stix_transmission/test_synchronous_dummy.py
@@ -1,34 +1,25 @@
 from stix_shifter.stix_transmission.src.modules.synchronous_dummy import synchronous_dummy_connector
 import unittest
 
+CONNECTION = {"host": "hostbla",  "port": "8080",  "path": "/"}
+
 
 class TestSynchronousDummyConnection(unittest.TestCase, object):
     def test_is_async(self):
         module = synchronous_dummy_connector
-        check_async = module.Connector().is_async
+        check_async = module.Connector(CONNECTION, None).is_async
         assert check_async == False
 
     def test_ping(self):
-        interface = synchronous_dummy_connector.Connector()
+        interface = synchronous_dummy_connector.Connector(CONNECTION, None)
         ping_result = interface.ping()
-        assert ping_result == "synchronous ping"
+        assert ping_result["success"] is True
 
     def test_dummy_sync_results(self):
-        options = {}
-        params = {
-            "config": {
-                "port": 443,
-                "ip": "127.0.0.1",
-                "host": "localhost",
-                "path": "/async_dummy/query_path"
-            },
-            "query": "placeholder query text"
-        }
+        interface = synchronous_dummy_connector.Connector(CONNECTION, None)
+        results_response = interface.create_results_connection("some query", 1, 1)
+        response_code = results_response["success"]
+        query_results = results_response["data"]
 
-        interface = synchronous_dummy_connector.Connector()
-        results_response = interface.create_results_connection(params, options)
-        response_code = results_response["response_code"]
-        query_results = results_response["query_results"]
-
-        assert response_code == 200
-        assert isinstance(query_results, dict)
+        assert response_code is True
+        assert query_results == "Results from search"


### PR DESCRIPTION
There were some missing method implementations that are used by ISC even though they don't actually do anything when the data source is synchronous. Updated the Elastic Search ECS and synchronous dummy transmission modules.

*** The below is required to be filled by any non-IBM employee, in order for their pull request to be accepted ***
DCO 1.1 Signed-off-by: [NAME] <[EMAIL]>
