### PR TITLE
remove CIM from-STIX mappings that were mapped to none

### DIFF
--- a/stix_shifter/stix_translation/src/modules/cim/json/from_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/cim/json/from_stix_map.json
@@ -1,6 +1,4 @@
 {
-    "artifact": "None",
-    "as": "None",
     "directory": {
         "cim_type": "endpoint",
         "fields": {
@@ -86,7 +84,6 @@
             ]
         }
     },
-    "mutex": "None",
     "network-traffic": {
         "cim_type": "network",
         "fields": {
@@ -109,7 +106,6 @@
             "binary_ref.name": "file_name"
         }
     },
-    "software": "None",
     "url": {
         "cim_type": "web",
         "fields": {


### PR DESCRIPTION
This was failing for some Splunk pattern translations due to pattern mappings being attributed to none. Example pattern that was failing:
`python main.py translate splunk query '{}' "[artifact:payload_bin = 'tealdkfjasdflasdj']"`

*** The below is required to be filled by any non-IBM employee, in order for their pull request to be accepted ***
DCO 1.1 Signed-off-by: [NAME] <[EMAIL]>
