### PR TITLE
Not equals translation fix

### DIFF
--- a/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
@@ -123,9 +123,9 @@ class QueryStringPatternTranslator:
         return stix_field == 'src_ref.value' or stix_field == 'dst_ref.value'
 
     @staticmethod
-    def _lookup_comparision_operator(self, expression_operator):
+    def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self.comparator_lookup:
-            raise NotImplementedError("Haven't implemented comparision operator {}".format(expression_operator))
+            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
         return self.comparator_lookup[expression_operator]
 
     def _parse_expression(self, expression, qualifier=None) -> str:
@@ -135,7 +135,7 @@ class QueryStringPatternTranslator:
             # Multiple data source fields may map to the same STIX Object
             mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
             # Resolve the comparison symbol to use in the query string (usually just ':')
-            comparator = self._lookup_comparision_operator(self, expression.comparator)
+            comparator = self._lookup_comparison_operator(self, expression.comparator)
 
             if stix_field == 'start' or stix_field == 'end':
                 transformer = TimestampToMilliseconds()
@@ -170,7 +170,7 @@ class QueryStringPatternTranslator:
                 return "{}".format(comparison_string)
 
         elif isinstance(expression, CombinedComparisonExpression):
-            operator = self._lookup_comparision_operator(self, expression.operator)
+            operator = self._lookup_comparison_operator(self, expression.operator)
             expression_01 = self._parse_expression(expression.expr1)
             expression_02 = self._parse_expression(expression.expr2)
             if not expression_01 or not expression_02:
@@ -188,7 +188,7 @@ class QueryStringPatternTranslator:
             return self._parse_expression(expression.comparison_expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
             if isinstance(expression.observation_expression, CombinedObservationExpression):
-                operator = self._lookup_comparision_operator(self, expression.observation_expression.operator)
+                operator = self._lookup_comparison_operator(self, expression.observation_expression.operator)
                 expression_01 = self._parse_expression(expression.observation_expression.expr1)
                 # qualifier only needs to be passed into the parse expression once since it will be the same for both expressions
                 expression_02 = self._parse_expression(expression.observation_expression.expr2, expression.qualifier)
@@ -196,7 +196,7 @@ class QueryStringPatternTranslator:
             else:
                 return self._parse_expression(expression.observation_expression.comparison_expression, expression.qualifier)
         elif isinstance(expression, CombinedObservationExpression):
-            operator = self._lookup_comparision_operator(self, expression.operator)
+            operator = self._lookup_comparison_operator(self, expression.operator)
             expression_01 = self._parse_expression(expression.expr1)
             expression_02 = self._parse_expression(expression.expr2)
             if expression_01 and expression_02:

--- a/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
@@ -125,7 +125,7 @@ class QueryStringPatternTranslator:
     @staticmethod
     def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self.comparator_lookup:
-            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
+            raise NotImplementedError("Comparison operator {} unsupported for Dummy adapter".format(expression_operator.name))
         return self.comparator_lookup[expression_operator]
 
     def _parse_expression(self, expression, qualifier=None) -> str:

--- a/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/dummy/query_constructor.py
@@ -78,7 +78,7 @@ class QueryStringPatternTranslator:
 
     @staticmethod
     def _negate_comparison(comparison_string):
-        return "NOT({})".format(comparison_string)
+        return "NOT ({})".format(comparison_string)
 
     @staticmethod
     def _check_value_type(value):
@@ -122,6 +122,12 @@ class QueryStringPatternTranslator:
     def _is_reference_value(stix_field):
         return stix_field == 'src_ref.value' or stix_field == 'dst_ref.value'
 
+    @staticmethod
+    def _lookup_comparision_operator(self, expression_operator):
+        if expression_operator not in self.comparator_lookup:
+            raise NotImplementedError("Haven't implemented comparision operator {}".format(expression_operator))
+        return self.comparator_lookup[expression_operator]
+
     def _parse_expression(self, expression, qualifier=None) -> str:
         if isinstance(expression, ComparisonExpression):  # Base Case
             # Resolve STIX Object Path to a field in the target Data Model
@@ -129,7 +135,7 @@ class QueryStringPatternTranslator:
             # Multiple data source fields may map to the same STIX Object
             mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
             # Resolve the comparison symbol to use in the query string (usually just ':')
-            comparator = self.comparator_lookup[expression.comparator]
+            comparator = self._lookup_comparision_operator(self, expression.comparator)
 
             if stix_field == 'start' or stix_field == 'end':
                 transformer = TimestampToMilliseconds()
@@ -156,9 +162,6 @@ class QueryStringPatternTranslator:
                 grouped_comparison_string = "(" + comparison_string + ")"
                 comparison_string = grouped_comparison_string
 
-            if expression.comparator == ComparisonComparators.NotEqual:
-                comparison_string = self._negate_comparison(comparison_string)
-
             if expression.negated:
                 comparison_string = self._negate_comparison(comparison_string)
             if qualifier is not None:
@@ -167,7 +170,7 @@ class QueryStringPatternTranslator:
                 return "{}".format(comparison_string)
 
         elif isinstance(expression, CombinedComparisonExpression):
-            operator = self.comparator_lookup[expression.operator]
+            operator = self._lookup_comparision_operator(self, expression.operator)
             expression_01 = self._parse_expression(expression.expr1)
             expression_02 = self._parse_expression(expression.expr2)
             if not expression_01 or not expression_02:
@@ -185,15 +188,15 @@ class QueryStringPatternTranslator:
             return self._parse_expression(expression.comparison_expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
             if isinstance(expression.observation_expression, CombinedObservationExpression):
-                operator = self.comparator_lookup[expression.observation_expression.operator]
+                operator = self._lookup_comparision_operator(self, expression.observation_expression.operator)
+                expression_01 = self._parse_expression(expression.observation_expression.expr1)
                 # qualifier only needs to be passed into the parse expression once since it will be the same for both expressions
-                return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.observation_expression.expr1),
-                                                           operator=operator,
-                                                           expr2=self._parse_expression(expression.observation_expression.expr2, expression.qualifier))
+                expression_02 = self._parse_expression(expression.observation_expression.expr2, expression.qualifier)
+                return "{} {} {}".format(expression_01, operator, expression_02)
             else:
                 return self._parse_expression(expression.observation_expression.comparison_expression, expression.qualifier)
         elif isinstance(expression, CombinedObservationExpression):
-            operator = self.comparator_lookup[expression.operator]
+            operator = self._lookup_comparision_operator(self, expression.operator)
             expression_01 = self._parse_expression(expression.expr1)
             expression_02 = self._parse_expression(expression.expr2)
             if expression_01 and expression_02:

--- a/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
@@ -153,7 +153,7 @@ class AqlQueryStringPatternTranslator:
     @staticmethod
     def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self.comparator_lookup:
-            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
+            raise NotImplementedError("Comparison operator {} unsupported for QRadar adapter".format(expression_operator.name))
         return self.comparator_lookup[expression_operator]
 
     @staticmethod

--- a/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
@@ -88,7 +88,7 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _negate_comparison(comparison_string):
-        return "NOT({})".format(comparison_string)
+        return "NOT ({})".format(comparison_string)
 
     @staticmethod
     def _check_value_type(value):
@@ -151,8 +151,14 @@ class AqlQueryStringPatternTranslator:
         return stix_field == 'src_ref.value' or stix_field == 'dst_ref.value'
 
     @staticmethod
+    def _lookup_comparision_operator(self, expression_operator):
+        if expression_operator not in self.comparator_lookup:
+            raise NotImplementedError("Haven't implemented comparision operator {}".format(expression_operator))
+        return self.comparator_lookup[expression_operator]
+
+    @staticmethod
     def _parse_combined_observation_expression(self, expression):
-        operator = self.comparator_lookup[expression.operator]
+        operator = self._lookup_comparision_operator(self, expression.operator)
         expression_01 = self._parse_expression(expression.expr1)
         expression_02 = self._parse_expression(expression.expr2)
         if expression_01 and expression_02:
@@ -170,7 +176,7 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _parse_combined_comparison_expression(self, expression, qualifier=None):
-        operator = self.comparator_lookup[expression.operator]
+        operator = self._lookup_comparision_operator(self, expression.operator)
         expression_01 = self._parse_expression(expression.expr1)
         expression_02 = self._parse_expression(expression.expr2)
         if not expression_01 or not expression_02:
@@ -193,7 +199,7 @@ class AqlQueryStringPatternTranslator:
         # Multiple QRadar fields may map to the same STIX Object
         mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
         # Resolve the comparison symbol to use in the query string (usually just ':')
-        comparator = self.comparator_lookup[expression.comparator]
+        comparator = self._lookup_comparision_operator(self, expression.comparator)
 
         if stix_field == 'protocols[*]':
             map_data = _fetch_network_protocol_mapping()
@@ -226,8 +232,6 @@ class AqlQueryStringPatternTranslator:
         if(len(mapped_fields_array) > 1 and not self._is_reference_value(stix_field)):
             # More than one AQL field maps to the STIX attribute so group the ORs.
             comparison_string = "({})".format(comparison_string)
-        if expression.comparator == ComparisonComparators.NotEqual:
-            comparison_string = self._negate_comparison(comparison_string)
         if expression.negated:
             comparison_string = self._negate_comparison(comparison_string)
         if qualifier:
@@ -245,7 +249,7 @@ class AqlQueryStringPatternTranslator:
             return self._parse_observation_expression(self, expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
             if isinstance(expression.observation_expression, CombinedObservationExpression):
-                operator = self.comparator_lookup[expression.observation_expression.operator]
+                operator = self._lookup_comparision_operator(self, expression.observation_expression.operator)
                 # qualifier only needs to be passed into the parse expression once since it will be the same for both expressions
                 return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.observation_expression.expr1),
                                                            operator=operator,

--- a/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/qradar/query_constructor.py
@@ -151,14 +151,14 @@ class AqlQueryStringPatternTranslator:
         return stix_field == 'src_ref.value' or stix_field == 'dst_ref.value'
 
     @staticmethod
-    def _lookup_comparision_operator(self, expression_operator):
+    def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self.comparator_lookup:
-            raise NotImplementedError("Haven't implemented comparision operator {}".format(expression_operator))
+            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
         return self.comparator_lookup[expression_operator]
 
     @staticmethod
     def _parse_combined_observation_expression(self, expression):
-        operator = self._lookup_comparision_operator(self, expression.operator)
+        operator = self._lookup_comparison_operator(self, expression.operator)
         expression_01 = self._parse_expression(expression.expr1)
         expression_02 = self._parse_expression(expression.expr2)
         if expression_01 and expression_02:
@@ -176,7 +176,7 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _parse_combined_comparison_expression(self, expression, qualifier=None):
-        operator = self._lookup_comparision_operator(self, expression.operator)
+        operator = self._lookup_comparison_operator(self, expression.operator)
         expression_01 = self._parse_expression(expression.expr1)
         expression_02 = self._parse_expression(expression.expr2)
         if not expression_01 or not expression_02:
@@ -199,7 +199,7 @@ class AqlQueryStringPatternTranslator:
         # Multiple QRadar fields may map to the same STIX Object
         mapped_fields_array = self.dmm.map_field(stix_object, stix_field)
         # Resolve the comparison symbol to use in the query string (usually just ':')
-        comparator = self._lookup_comparision_operator(self, expression.comparator)
+        comparator = self._lookup_comparison_operator(self, expression.comparator)
 
         if stix_field == 'protocols[*]':
             map_data = _fetch_network_protocol_mapping()
@@ -249,7 +249,7 @@ class AqlQueryStringPatternTranslator:
             return self._parse_observation_expression(self, expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
             if isinstance(expression.observation_expression, CombinedObservationExpression):
-                operator = self._lookup_comparision_operator(self, expression.observation_expression.operator)
+                operator = self._lookup_comparison_operator(self, expression.observation_expression.operator)
                 # qualifier only needs to be passed into the parse expression once since it will be the same for both expressions
                 return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.observation_expression.expr1),
                                                            operator=operator,

--- a/stix_shifter/stix_translation/src/modules/splunk/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/query_constructor.py
@@ -136,7 +136,7 @@ class _ObservationExpressionTranslator:
     @staticmethod
     def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self._comparators:
-            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
+            raise NotImplementedError("Comparison operator {} unsupported for Splunk adapter".format(expression_operator.name))
         return self._comparators[expression_operator]
 
     def translate(self, expression):

--- a/stix_shifter/stix_translation/src/modules/splunk/query_constructor.py
+++ b/stix_shifter/stix_translation/src/modules/splunk/query_constructor.py
@@ -134,9 +134,9 @@ class _ObservationExpressionTranslator:
         self.object_scoper = object_scoper
 
     @staticmethod
-    def _lookup_comparision_operator(self, expression_operator):
+    def _lookup_comparison_operator(self, expression_operator):
         if expression_operator not in self._comparators:
-            raise NotImplementedError("Haven't implemented comparision operator {}".format(expression_operator))
+            raise NotImplementedError("Haven't implemented comparison operator {}".format(expression_operator))
         return self._comparators[expression_operator]
 
     def translate(self, expression):
@@ -180,7 +180,7 @@ class _ObservationExpressionTranslator:
             )
 
     def _build_comparison(self, expression, object_scoping, field_mapping):
-        comparator = self._lookup_comparision_operator(self, expression.comparator)
+        comparator = self._lookup_comparison_operator(self, expression.comparator)
         if isinstance(comparator, str):
             splunk_comparison = self._maybe_negate("{} {} {}".format(
                 field_mapping,

--- a/stix_shifter/stix_translation/src/utils/stix_pattern_parser.py
+++ b/stix_shifter/stix_translation/src/utils/stix_pattern_parser.py
@@ -44,6 +44,8 @@ class PatternTranslator:
             # Resolve STIX Object Path to a field in the target Data Model
             stix_object, stix_field = expression.object_path.split(':')
             comparator = self.comparator_lookup[expression.comparator]
+            if expression.negated:
+                comparator = 'NOT ' + comparator
             if qualifier is not None:
                 self._convert_qualifier_times_to_unix_times(qualifier)
             self.parsed_pattern.append({'attribute': expression.object_path, 'comparison_operator': comparator, 'value': expression.value})

--- a/tests/stix_translation/qradar_stix_to_aql/test_class.py
+++ b/tests/stix_translation/qradar_stix_to_aql/test_class.py
@@ -58,6 +58,13 @@ class TestStixToAql(unittest.TestCase, object):
         where_statement = "WHERE url = 'http://www.testaddress.com' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
+    def test_NOT_and_not_equals_operators(self):
+        stix_pattern = "[url:value != 'www.example.com' OR url:value NOT = 'www.example.ca']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE NOT (url = 'www.example.ca') OR url != 'www.example.com' {} {}".format(
+            default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)
+
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = _translate_query(stix_pattern)

--- a/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -53,6 +53,18 @@ class TestStixToSpl(unittest.TestCase, object):
         queries = 'search (url = "http://www.testaddress.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
         _test_query_assertions(query, queries)
 
+    def test_not_equal_operator(self):
+        stix_pattern = "[url:value != 'http://www.testaddress.com']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = 'search (url != "http://www.testaddress.com") earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
+        _test_query_assertions(query, queries)
+
+    def test_NOT_operator(self):
+        stix_pattern = "[url:value NOT = 'http://www.testaddress.com']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = 'search (NOT (url = "http://www.testaddress.com")) earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol'
+        _test_query_assertions(query, queries)
+
     def test_mac_address_query(self):
         stix_pattern = "[mac-addr:value = '00-00-5E-00-53-00']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)

--- a/tests/stix_translation/test_stix_parsing.py
+++ b/tests/stix_translation/test_stix_parsing.py
@@ -60,3 +60,13 @@ class TestStixParsing(unittest.TestCase, object):
         # The biggest time window should be returned
         assert parsing['start_time'] == 1464744600123
         assert parsing['end_time'] == 1464755424743
+
+    def test_not_equals_operator(self):
+        stix_pattern = "[url:value != 'example.com' OR url:value NOT = 'test.com']"
+        parsing = _parse_query(stix_pattern)
+        parsed_stix = [{'attribute': 'url:value', 'comparison_operator': 'NOT =', 'value': 'test.com'},
+                       {'attribute': 'url:value', 'comparison_operator': '!=', 'value': 'example.com'}]
+        assert parsing['parsed_stix'] == parsed_stix
+        # Time window should be last 5 minutes from frozen time
+        assert parsing['start_time'] == 1548926700000
+        assert parsing['end_time'] == 1548927000000


### PR DESCRIPTION
Adds error handling for cases where an adapter is missing a comparison operator
Fixes how the `NOT` operator gets applied to native AQL translations
Adds some unit tests around the `NOT` and `!=` operators

*** The below is required to be filled by any non-IBM employee, in order for their pull request to be accepted ***
DCO 1.1 Signed-off-by: [NAME] <[EMAIL]>
